### PR TITLE
Implement Codex wake spooler MVP

### DIFF
--- a/.codex/hooks/wake_user_prompt_submit.py
+++ b/.codex/hooks/wake_user_prompt_submit.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+def main() -> int:
+    repo_root = Path(__file__).resolve().parents[2]
+    sys.path.insert(0, str(repo_root / "src"))
+    from codex_wake.hook import main as hook_main
+
+    return hook_main()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/README.md
+++ b/README.md
@@ -1,0 +1,19 @@
+# Codex Wake
+
+Codex Wake is a local wake spooler for TUI-bound Codex agents.
+
+The first implementation target is a small `codex-wake` CLI that writes declarative wake records under `.codex/wake/`. Later slices add the daemon, tmux injector, and Codex hook ack flow described in [docs/dev/0001-wake-spooler-design.md](docs/dev/0001-wake-spooler-design.md).
+
+## Development
+
+Run the focused test suite:
+
+```bash
+PYTHONPATH=src python -m unittest discover -s tests -p 'test_*.py'
+```
+
+Run the CLI from source:
+
+```bash
+PYTHONPATH=src python -m codex_wake.cli --help
+```

--- a/README.md
+++ b/README.md
@@ -18,6 +18,12 @@ Run the CLI from source:
 PYTHONPATH=src python -m codex_wake.cli --help
 ```
 
+Archive terminal wake records:
+
+```bash
+PYTHONPATH=src python -m codex_wake.cli archive --all-terminal
+```
+
 Run one daemon polling pass from source:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -18,6 +18,12 @@ Run the CLI from source:
 PYTHONPATH=src python -m codex_wake.cli --help
 ```
 
+Create an app-server-targeted wake instead of a tmux-targeted wake:
+
+```bash
+PYTHONPATH=src python -m codex_wake.cli after --app-server-thread-id thread_abc 45m -- "Resume the scheduled task."
+```
+
 Archive terminal wake records:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -17,3 +17,9 @@ Run the CLI from source:
 ```bash
 PYTHONPATH=src python -m codex_wake.cli --help
 ```
+
+Run one daemon polling pass from source:
+
+```bash
+PYTHONPATH=src python -m codex_wake.daemon --once
+```

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -60,9 +60,9 @@ Planned behavior:
 
 ## P04 | Tmux Injection MVP
 
-State: OPEN
+State: CLOSED
 
-Current State: The daemon can move eligible records into `firing`, but no injector exists yet. MVP injection should paste a short canonical wake prompt into the captured pane and press Enter.
+Current State: Closed by the first tmux injector implementation. Firing records can be dispatched through a testable injector path, canonical prompts are generated from wake id only, unsafe panes are rejected, per-pane locks are enforced, and missing ack requeues with backoff.
 
 Plan: [Tmux Injection MVP](docs/dev/plans/0004-2026-05-18-tmux-injection-mvp.md)
 
@@ -82,9 +82,11 @@ Resume the scheduled wake task.
 
 ## P05 | Codex Hook Ack And Context Loader
 
-State: PLANNED
+State: OPEN
 
-Current State: No hook exists yet. This lane should implement the repo-local `UserPromptSubmit` hook and a sample config fragment.
+Current State: The injector now waits for `.codex/wake/acks/<wake-id>.submitted`, but no Codex hook exists yet. This lane should implement the repo-local `UserPromptSubmit` hook and a sample config fragment.
+
+Plan: [Codex Hook Ack And Context Loader](docs/dev/plans/0005-2026-05-18-codex-hook-ack-context-loader.md)
 
 Planned behavior:
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -82,9 +82,9 @@ Resume the scheduled wake task.
 
 ## P05 | Codex Hook Ack And Context Loader
 
-State: OPEN
+State: CLOSED
 
-Current State: The injector now waits for `.codex/wake/acks/<wake-id>.submitted`, but no Codex hook exists yet. This lane should implement the repo-local `UserPromptSubmit` hook and a sample config fragment.
+Current State: Closed by the repo-local `UserPromptSubmit` hook. The hook self-filters for `WAKE_TRIGGER_ID=...`, writes ack files, and returns wake context through `hookSpecificOutput.additionalContext`.
 
 Plan: [Codex Hook Ack And Context Loader](docs/dev/plans/0005-2026-05-18-codex-hook-ack-context-loader.md)
 
@@ -98,9 +98,11 @@ Planned behavior:
 
 ## P06 | Runtime State, Retention, And Safety
 
-State: PLANNED
+State: OPEN
 
-Current State: Policy requires runtime state classification, but no concrete layout exists yet.
+Current State: Core runtime directories exist and wake records carry deterministic statuses and events. This lane should finalize retention, archive, cleanup, and safety documentation around the active runtime layout.
+
+Plan: [Runtime State, Retention, And Safety](docs/dev/plans/0006-2026-05-18-runtime-state-retention-safety.md)
 
 Planned state layout:
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -98,9 +98,9 @@ Planned behavior:
 
 ## P06 | Runtime State, Retention, And Safety
 
-State: OPEN
+State: CLOSED
 
-Current State: Core runtime directories exist and wake records carry deterministic statuses and events. This lane should finalize retention, archive, cleanup, and safety documentation around the active runtime layout.
+Current State: Closed by runtime-state documentation and the terminal-record archive command. Operators can inspect active and archived wakes, and terminal wake records can be archived without touching active `pending` or `firing` records.
 
 Plan: [Runtime State, Retention, And Safety](docs/dev/plans/0006-2026-05-18-runtime-state-retention-safety.md)
 
@@ -122,9 +122,11 @@ Safety requirements:
 
 ## P07 | App-Server Controlled Mode
 
-State: PLANNED
+State: OPEN
 
-Current State: This is the preferred long-term mode, but it should follow the tmux MVP.
+Current State: The tmux MVP path exists. This is the preferred long-term mode and should now be designed against the current Codex app-server contract before implementation.
+
+Plan: [App-Server Controlled Mode](docs/dev/plans/0007-2026-05-18-app-server-controlled-mode.md)
 
 Planned behavior:
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,9 +2,9 @@
 
 ## P01 | Wake Spooler Architecture
 
-State: OPEN
+State: CLOSED
 
-Current State: The repo has policy and planning surfaces. The accepted architecture direction is a wake spooler: agents request wakes through `codex-wake`, deterministic runtime code owns trigger persistence and firing, and the MVP targets a live Codex TUI through tmux plus a `UserPromptSubmit` hook ack.
+Current State: Closed by `docs/dev/0001-wake-spooler-design.md`. The accepted architecture direction is a wake spooler: agents request wakes through `codex-wake`, deterministic runtime code owns trigger persistence and firing, and the MVP targets a live Codex TUI through tmux plus a `UserPromptSubmit` hook ack.
 
 Plan: [Initial Wake Timer Design](docs/dev/plans/0001-2026-05-18-initial-wake-timer-design.md)
 
@@ -18,9 +18,11 @@ Deliverables:
 
 ## P02 | Agent-Facing CLI
 
-State: PLANNED
+State: CLOSED
 
-Current State: No CLI exists yet. This lane opens after P01 fixes the wake-record schema and trigger vocabulary.
+Current State: Closed by the first Python package and CLI implementation. `codex-wake` can create `after`, `at`, and `file` wake records, list records, show a record, and cancel pending or firing records.
+
+Plan: [Agent-Facing CLI](docs/dev/plans/0002-2026-05-18-agent-facing-cli.md)
 
 Planned surface:
 
@@ -40,9 +42,11 @@ Acceptance target:
 
 ## P03 | Wake Daemon And Trigger Engine
 
-State: PLANNED
+State: OPEN
 
-Current State: No daemon exists yet. The first implementation should be a small polling daemon rather than systemd, cron, or a general TUI automation controller.
+Current State: The CLI can create declarative wake records. No daemon exists yet. The first daemon implementation should be a small polling daemon rather than systemd, cron, or a general TUI automation controller.
+
+Plan: [Wake Daemon And Trigger Engine](docs/dev/plans/0003-2026-05-18-wake-daemon-trigger-engine.md)
 
 Planned behavior:
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -122,9 +122,9 @@ Safety requirements:
 
 ## P07 | App-Server Controlled Mode
 
-State: OPEN
+State: CLOSED
 
-Current State: The tmux MVP path exists. This is the preferred long-term mode and should now be designed against the current Codex app-server contract before implementation.
+Current State: Closed by the stdio app-server controlled dispatch path. Wake records can target app-server threads, dispatch uses `initialize`, `thread/resume`, and `turn/start`, and WebSocket mode remains explicitly deferred behind the documented experimental/auth boundary.
 
 Plan: [App-Server Controlled Mode](docs/dev/plans/0007-2026-05-18-app-server-controlled-mode.md)
 
@@ -138,9 +138,11 @@ Planned behavior:
 
 ## P08 | Installed Runtime Verification
 
-State: PLANNED
+State: OPEN
 
-Current State: No installed command, hook, or daemon exists yet. This lane opens once there is an executable surface.
+Current State: The CLI, daemon, tmux injector, Codex hook, archive controls, and stdio app-server dispatch path exist on the feature branch. This lane should verify the installed executable surface end to end.
+
+Plan: [Installed Runtime Verification](docs/dev/plans/0008-2026-05-18-installed-runtime-verification.md)
 
 Acceptance target:
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -138,9 +138,9 @@ Planned behavior:
 
 ## P08 | Installed Runtime Verification
 
-State: OPEN
+State: CLOSED
 
-Current State: The CLI, daemon, tmux injector, Codex hook, archive controls, and stdio app-server dispatch path exist on the feature branch. This lane should verify the installed executable surface end to end.
+Current State: Closed by `docs/dev/verification/0001-2026-05-18-installed-runtime-verification.md`. Installed console scripts, CLI lifecycle, daemon predicate movement, hook ack behavior, and app-server target creation were verified from a temporary virtualenv.
 
 Plan: [Installed Runtime Verification](docs/dev/plans/0008-2026-05-18-installed-runtime-verification.md)
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -42,9 +42,9 @@ Acceptance target:
 
 ## P03 | Wake Daemon And Trigger Engine
 
-State: OPEN
+State: CLOSED
 
-Current State: The CLI can create declarative wake records. No daemon exists yet. The first daemon implementation should be a small polling daemon rather than systemd, cron, or a general TUI automation controller.
+Current State: Closed by the first `codex-waked` implementation. The daemon can poll pending records, evaluate `not_before` and `file_exists`, move ready records into `firing`, and fail records with invalid predicates.
 
 Plan: [Wake Daemon And Trigger Engine](docs/dev/plans/0003-2026-05-18-wake-daemon-trigger-engine.md)
 
@@ -60,9 +60,11 @@ Planned behavior:
 
 ## P04 | Tmux Injection MVP
 
-State: PLANNED
+State: OPEN
 
-Current State: No injector exists yet. MVP injection should paste a short canonical wake prompt into the captured pane and press Enter.
+Current State: The daemon can move eligible records into `firing`, but no injector exists yet. MVP injection should paste a short canonical wake prompt into the captured pane and press Enter.
+
+Plan: [Tmux Injection MVP](docs/dev/plans/0004-2026-05-18-tmux-injection-mvp.md)
 
 Planned behavior:
 

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -51,3 +51,24 @@ Validation:
 - `TMUX_PANE='%11' TMUX='/tmp/tmux-1000/default,123,0' PYTHONPATH=src python -m codex_wake.cli --wake-root /tmp/codex-wake-smoke after 1m -- 'Smoke wake'`
 
 Next checkpoint: implement `codex-waked` predicate polling and `pending -> firing` movement for `not_before` and `file_exists`.
+
+## Turn 5 | 2026-05-18
+
+Implemented and validated the P03 daemon slice.
+
+- Added `codex-waked` as a console entry point.
+- Added one-shot and polling daemon modes.
+- Added predicate evaluation for `not_before` and `file_exists`.
+- Added deterministic movement from `pending` to `firing`.
+- Added invalid-predicate movement from `pending` to `failed`.
+- Added stable transition events and `last_error` support.
+- Closed P03 in `ROADMAP.md`.
+- Opened P04 with `docs/dev/plans/0004-2026-05-18-tmux-injection-mvp.md`.
+
+Validation:
+
+- `PYTHONPATH=src python -m unittest discover -s tests -p 'test_*.py'`
+- `PYTHONPATH=src python -m codex_wake.daemon --once --wake-root /tmp/codex-wake-daemon-smoke`
+- create an already-due wake through `codex-wake`, then run `codex-waked --once` and verify the record moved to `firing`.
+
+Next checkpoint: implement the tmux injector, per-pane locking, unsafe pane checks, and bounded missing-ack behavior.

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -21,3 +21,33 @@ Roadmapped the wake-spooler design from the supplied design note.
 - Verified current Codex docs for `UserPromptSubmit`, hook timeout/async behavior, `codex exec resume`, remote TUI mode, and app-server `thread/resume` plus `turn/start`.
 
 Next checkpoint: write the source-backed design brief and first wake-record contract under `docs/dev/`.
+
+## Turn 3 | 2026-05-18
+
+Started execution on P01 and moved the repo into the first implementation slice.
+
+- Added `docs/dev/0001-wake-spooler-design.md` with the accepted architecture, schema, status vocabulary, event records, hook ack contract, retry policy, CLI contract, and validation requirements.
+- Closed P01 in `ROADMAP.md`.
+- Opened P02 in `ROADMAP.md`.
+- Added `docs/dev/plans/0002-2026-05-18-agent-facing-cli.md` as the active implementation plan.
+
+Next checkpoint: implement the `codex-wake` CLI and tests for wake-record creation, listing, showing, and cancellation.
+
+## Turn 4 | 2026-05-18
+
+Implemented and validated the P02 CLI slice.
+
+- Added Python package metadata and a `codex-wake` console entry point.
+- Added `after`, `at`, `file`, `list`, `show`, and `cancel` command support.
+- Added wake-record helpers for duration parsing, timestamp normalization, tmux target capture, atomic JSON writes, record lookup, and cancellation.
+- Added focused standard-library tests for records and CLI behavior.
+- Closed P02 in `ROADMAP.md`.
+- Opened P03 with `docs/dev/plans/0003-2026-05-18-wake-daemon-trigger-engine.md`.
+
+Validation:
+
+- `PYTHONPATH=src python -m unittest discover -s tests -p 'test_*.py'`
+- `PYTHONPATH=src python -m codex_wake.cli --help`
+- `TMUX_PANE='%11' TMUX='/tmp/tmux-1000/default,123,0' PYTHONPATH=src python -m codex_wake.cli --wake-root /tmp/codex-wake-smoke after 1m -- 'Smoke wake'`
+
+Next checkpoint: implement `codex-waked` predicate polling and `pending -> firing` movement for `not_before` and `file_exists`.

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -72,3 +72,21 @@ Validation:
 - create an already-due wake through `codex-wake`, then run `codex-waked --once` and verify the record moved to `firing`.
 
 Next checkpoint: implement the tmux injector, per-pane locking, unsafe pane checks, and bounded missing-ack behavior.
+
+## Turn 6 | 2026-05-18
+
+Implemented and validated the P04 tmux injector slice.
+
+- Added `codex_wake.injector` with canonical prompt construction, tmux subprocess runner, pane capture, prompt paste, per-pane locks, ack waiting, and bounded requeue/fail behavior.
+- Wired `codex-waked` to dispatch `firing` records by default, with `--no-dispatch` and `--ack-timeout` controls.
+- Ensured injected text contains only `WAKE_TRIGGER_ID=<id>` and the short resume instruction.
+- Added tests for canonical prompt construction, unsafe pane detection, lock contention, submitted ack behavior, missing-ack requeue, and full-prompt exclusion from injected text.
+- Closed P04 in `ROADMAP.md`.
+- Opened P05 with `docs/dev/plans/0005-2026-05-18-codex-hook-ack-context-loader.md`.
+
+Validation:
+
+- `PYTHONPATH=src python -m unittest discover -s tests -p 'test_*.py'`
+- `python -m compileall -q src tests`
+
+Next checkpoint: implement the `UserPromptSubmit` hook that writes ack files and injects wake context into Codex.

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -130,3 +130,25 @@ Validation:
 - `python -m compileall -q src tests .codex/hooks`
 
 Next checkpoint: verify current Codex app-server contract and decide whether P07 can implement controlled dispatch now or should record a precise blocker.
+
+## Turn 9 | 2026-05-18
+
+Implemented and validated the P07 app-server controlled mode slice.
+
+- Verified official Codex docs for app-server transports and WebSocket safety boundaries.
+- Verified local Codex CLI 0.130.0 supports `codex app-server --listen stdio://`, schema generation, and TypeScript generation.
+- Generated local app-server schemas and confirmed `thread/resume` and `turn/start` payload shapes.
+- Added `codex_wake.app_server` with a stdio JSON-RPC client and controlled dispatch through `initialize`, `thread/resume`, and `turn/start`.
+- Added app-server target support through `--app-server-thread-id`.
+- Explicitly rejected non-stdio app-server endpoints in the MVP.
+- Added `docs/dev/app-server-mode.md`.
+- Added tests for app-server dispatch, unsupported endpoint failure, dispatcher routing, and CLI target creation.
+- Closed P07 in `ROADMAP.md`.
+- Opened P08 with `docs/dev/plans/0008-2026-05-18-installed-runtime-verification.md`.
+
+Validation:
+
+- `PYTHONPATH=src python -m unittest discover -s tests -p 'test_*.py'`
+- `python -m compileall -q src tests .codex/hooks`
+
+Next checkpoint: verify installed executables and hook behavior end to end from a temporary install.

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -90,3 +90,23 @@ Validation:
 - `python -m compileall -q src tests`
 
 Next checkpoint: implement the `UserPromptSubmit` hook that writes ack files and injects wake context into Codex.
+
+## Turn 7 | 2026-05-18
+
+Implemented and validated the P05 Codex hook slice.
+
+- Added `codex_wake.hook` with wake id extraction, ack writing, trigger lookup, missing-trigger warnings, and hook-specific JSON output.
+- Added `.codex/hooks/wake_user_prompt_submit.py` as the repo-local command hook wrapper.
+- Added `docs/dev/codex-hooks.example.json` with a sample `UserPromptSubmit` hook configuration.
+- Added tests for no-match, found-record, missing-record, and direct hook output behavior.
+- Verified official Codex hook docs for `UserPromptSubmit` matcher behavior and `hookSpecificOutput.additionalContext`.
+- Closed P05 in `ROADMAP.md`.
+- Opened P06 with `docs/dev/plans/0006-2026-05-18-runtime-state-retention-safety.md`.
+
+Validation:
+
+- `PYTHONPATH=src python -m unittest discover -s tests -p 'test_*.py'`
+- direct `.codex/hooks/wake_user_prompt_submit.py` smoke with a generated JSON payload
+- `python -m compileall -q src tests .codex/hooks`
+
+Next checkpoint: specify and implement runtime-state retention, archive, and cleanup behavior.

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -152,3 +152,25 @@ Validation:
 - `python -m compileall -q src tests .codex/hooks`
 
 Next checkpoint: verify installed executables and hook behavior end to end from a temporary install.
+
+## Turn 10 | 2026-05-18
+
+Completed P08 installed runtime verification.
+
+- Installed the package into `/tmp/codex-wake-venv`.
+- Verified installed `codex-wake --help`.
+- Verified installed `codex-waked --once --no-dispatch`.
+- Verified installed CLI create, list, cancel, and archive lifecycle.
+- Verified installed daemon predicate movement for an already-due wake with `--no-dispatch`.
+- Verified the repo-local hook wrapper writes an ack and returns hook-specific output from a JSON payload.
+- Verified installed app-server-targeted wake creation and JSON listing.
+- Recorded verification details in `docs/dev/verification/0001-2026-05-18-installed-runtime-verification.md`.
+- Closed P08 in `ROADMAP.md`.
+
+Known limits:
+
+- Live tmux dispatch was not attempted without a disposable Codex TUI pane target.
+- Live app-server dispatch was not attempted without a real target thread id.
+- WebSocket app-server dispatch remains intentionally unimplemented.
+
+Next checkpoint: open PR for review and merge planning.

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -110,3 +110,23 @@ Validation:
 - `python -m compileall -q src tests .codex/hooks`
 
 Next checkpoint: specify and implement runtime-state retention, archive, and cleanup behavior.
+
+## Turn 8 | 2026-05-18
+
+Implemented and validated the P06 runtime-state retention slice.
+
+- Added `docs/dev/runtime-state.md` documenting runtime directory classes, retention rules, safety rules, and archive commands.
+- Added `codex-wake archive <wake-id>`.
+- Added `codex-wake archive --all-terminal`.
+- Added `codex-wake list --archived`.
+- Added archive helpers that only move terminal records and preserve JSON with `previous_status`, `archived_at`, and an `archived` event.
+- Added tests for single-record archive, archive-all-terminal, CLI archive, and archived listing.
+- Closed P06 in `ROADMAP.md`.
+- Opened P07 with `docs/dev/plans/0007-2026-05-18-app-server-controlled-mode.md`.
+
+Validation:
+
+- `PYTHONPATH=src python -m unittest discover -s tests -p 'test_*.py'`
+- `python -m compileall -q src tests .codex/hooks`
+
+Next checkpoint: verify current Codex app-server contract and decide whether P07 can implement controlled dispatch now or should record a precise blocker.

--- a/docs/dev/0001-wake-spooler-design.md
+++ b/docs/dev/0001-wake-spooler-design.md
@@ -1,0 +1,307 @@
+# Wake Spooler Design
+
+Status: ACCEPTED
+Date: 2026-05-18
+Roadmap Lane: P01
+
+## Purpose
+
+Codex Wake is a local wake spooler for TUI-bound Codex agents. It gives an agent a narrow command surface for registering delayed follow-up work, while deterministic runtime code owns persistence, trigger evaluation, target selection, retries, and final status.
+
+This project is not a general TUI automation controller. The first product contract is:
+
+```text
+Codex TUI agent
+  -> codex-wake after/at/file ...
+  -> validated trigger record
+  -> codex-waked evaluates predicates
+  -> tmux injector submits a short canonical prompt
+  -> UserPromptSubmit hook records ack and loads full context
+```
+
+## Design Principles
+
+- The model may request a wake, but it does not own the timer.
+- Wake records are declarative data, not executable scripts.
+- The daemon owns trigger evaluation, state transitions, retry policy, and target dispatch.
+- The injector pastes only a short wake id prompt.
+- The hook loads full context after Codex accepts the wake prompt.
+- Every wake prompt must be idempotent and must first verify whether the work is already complete.
+- Missing ack, unsafe pane state, timeout, cancellation, and duplicate dispatch are explicit outcomes.
+
+## MVP Transport
+
+The MVP transport is tmux.
+
+At trigger creation, `codex-wake` captures:
+
+- current working directory
+- `TMUX_PANE`
+- tmux socket or enough environment to resolve it
+- creation timestamp
+- trigger predicate
+- continuation prompt
+
+At trigger firing, `codex-waked` uses a tmux injector to:
+
+- acquire a per-pane lock
+- capture the pane before injection
+- reject obvious unsafe pane states
+- paste the canonical wake prompt
+- press Enter
+- wait for a hook ack file
+
+The canonical prompt is:
+
+```text
+WAKE_TRIGGER_ID=<wake-id>
+Resume the scheduled wake task.
+```
+
+The full continuation text remains in the wake record and is added to model-visible context by the hook.
+
+## Future Transport
+
+The preferred controlled transport is Codex app-server.
+
+That mode should:
+
+- store an app-server thread id when available
+- resume the thread with `thread/resume`
+- start the wake turn with `turn/start`
+- avoid terminal paste heuristics
+- require localhost, SSH forwarding, or authenticated TLS for WebSocket use
+
+`codex exec resume <session-id> ...` remains a fallback when a live TUI pane is not required.
+
+## Runtime Root
+
+Default runtime root:
+
+```text
+.codex/wake/
+```
+
+Initial layout:
+
+```text
+.codex/wake/
+  pending/
+  firing/
+  submitted/
+  failed/
+  cancelled/
+  expired/
+  acks/
+  logs/
+  locks/
+  archive/
+```
+
+The runtime root is intentionally ignored by git. Fixtures and examples belong under tracked docs or tests, not under live runtime directories.
+
+## Wake Record Schema
+
+Version 1 wake records are JSON objects.
+
+Required fields:
+
+```json
+{
+  "schema_version": 1,
+  "id": "wake_20260518_153000_9f3a",
+  "created_at": "2026-05-18T20:30:00Z",
+  "updated_at": "2026-05-18T20:30:00Z",
+  "cwd": "/home/user/project",
+  "target": {
+    "transport": "tmux",
+    "tmux_socket": "/tmp/tmux-1000/default",
+    "pane": "%11"
+  },
+  "predicate": {
+    "type": "not_before",
+    "due_at": "2026-05-18T21:15:00Z"
+  },
+  "prompt": "This is wake trigger wake_20260518_153000_9f3a. First verify whether the task is already complete. If not, continue from the recorded context.",
+  "status": "pending",
+  "attempts": 0,
+  "max_attempts": 3,
+  "ack_timeout_seconds": 30,
+  "next_attempt_at": "2026-05-18T21:15:00Z",
+  "events": []
+}
+```
+
+Optional fields:
+
+- `created_by_session`
+- `created_by_profile`
+- `expires_at`
+- `last_error`
+- `context_paths`
+- `evidence_paths`
+- `result_summary`
+
+## Predicates
+
+MVP predicates:
+
+- `not_before`: fires when `due_at <= now`.
+- `file_exists`: fires when the path exists relative to `cwd`, unless absolute.
+
+Deferred predicates:
+
+- `file_changed`: requires recording the file's registration-time stat data.
+- `process_done`: requires clear ownership and stale-pid handling.
+- external checks: require an explicit safety design.
+- arbitrary command predicates: out of scope.
+
+Predicate records must be declarative. They must not contain shell commands.
+
+## Status Vocabulary
+
+Allowed statuses:
+
+- `pending`: created and awaiting predicate.
+- `firing`: predicate matched and dispatch is in progress.
+- `submitted`: Codex hook ack was observed.
+- `failed`: dispatch or validation failed permanently.
+- `cancelled`: user or operator cancelled the wake.
+- `expired`: wake exceeded its expiry before successful submission.
+- `archived`: wake was moved out of active state after retention handling.
+
+The daemon may derive operational substate from `events`, `attempts`, `next_attempt_at`, and `last_error`; it should not create ad hoc status strings.
+
+## Event Records
+
+Every meaningful transition appends an event object:
+
+```json
+{
+  "at": "2026-05-18T21:15:03Z",
+  "type": "dispatch_attempt",
+  "message": "Pasting canonical wake prompt into tmux pane %11",
+  "attempt": 1
+}
+```
+
+Event types should be stable enough for tests and operator inspection.
+
+Initial event types:
+
+- `created`
+- `predicate_matched`
+- `dispatch_attempt`
+- `unsafe_pane`
+- `ack_observed`
+- `ack_timeout`
+- `requeued`
+- `failed`
+- `cancelled`
+- `expired`
+- `archived`
+
+## Hook Ack Contract
+
+The `UserPromptSubmit` hook self-filters for:
+
+```text
+WAKE_TRIGGER_ID=<wake-id>
+```
+
+On match, it writes:
+
+```text
+.codex/wake/acks/<wake-id>.submitted
+```
+
+Ack JSON:
+
+```json
+{
+  "wake_id": "wake_20260518_153000_9f3a",
+  "submitted_at": "2026-05-18T21:15:05Z",
+  "turn_id": "turn_...",
+  "session_id": "session_..."
+}
+```
+
+The hook also loads the wake JSON and adds developer context containing:
+
+- wake id
+- predicate
+- original prompt
+- evidence paths
+- instruction to verify the predicate before editing files
+
+If the trigger file is missing, the hook still writes an ack and adds context telling the agent to inspect `.codex/wake/` before proceeding.
+
+## Unsafe Pane Heuristics
+
+The MVP tmux injector should inspect captured pane text before dispatch and reject obvious unsafe states.
+
+Initial reject patterns:
+
+- approval or confirmation prompt
+- active tool command still streaming
+- shell prompt instead of Codex TUI
+- existing partial input at the prompt
+- pane no longer exists
+
+These heuristics are intentionally conservative. False negatives are worse than delayed wakes.
+
+## Retry Policy
+
+Default policy:
+
+- set `status=firing` before injection
+- attempt dispatch
+- wait up to `ack_timeout_seconds`
+- if no ack, requeue with bounded backoff
+- after `max_attempts`, mark `failed`
+
+Backoff:
+
+- attempt 1: immediate
+- attempt 2: 60 seconds
+- attempt 3: 300 seconds
+
+The daemon must not retry in a tight loop.
+
+## CLI Contract
+
+Initial commands:
+
+```bash
+codex-wake after 45m -- "Continue the migration..."
+codex-wake at "2026-05-18T17:30:00-05:00" -- "Check whether the release branch is ready."
+codex-wake file .codex/events/pytest.done -- "Pytest finished. Read .codex/events/pytest.log."
+codex-wake list
+codex-wake show <wake-id>
+codex-wake cancel <wake-id>
+```
+
+Creation commands print the wake id and trigger path.
+
+Inspection commands must read state without mutating it, except `cancel`.
+
+## Validation Requirements
+
+Before MVP can be called working:
+
+- `after` creates a valid `not_before` wake.
+- `at` creates a valid UTC `not_before` wake.
+- `file` creates a valid `file_exists` wake.
+- daemon changes `pending -> firing -> submitted` when the hook ack appears.
+- daemon changes `firing -> pending` with backoff when ack is missing.
+- daemon changes `firing -> failed` after max attempts.
+- cancellation is explicit and inspectable.
+- trigger JSON never executes commands.
+- runtime state survives process restart.
+
+## Open Questions
+
+- Whether v1 should use one JSON file moved between status directories, or one stable file with a status field plus indexes.
+- Whether `created_by_session` can be reliably captured from current Codex TUI environment.
+- Whether pane-state heuristics should be configurable per Codex version.
+- Whether the app-server mode should become v2 or a parallel v1 transport.

--- a/docs/dev/app-server-mode.md
+++ b/docs/dev/app-server-mode.md
@@ -1,0 +1,64 @@
+# App-Server Mode
+
+Status: MVP stdio transport implemented
+Verified: 2026-05-18 with Codex CLI 0.130.0
+
+## Contract
+
+Codex Wake supports an app-server target record shape for controlled dispatch:
+
+```json
+{
+  "target": {
+    "transport": "app-server",
+    "endpoint": "stdio://",
+    "thread_id": "thread_..."
+  }
+}
+```
+
+The implemented path starts or uses a stdio app-server client and sends:
+
+1. `initialize`
+2. `thread/resume`
+3. `turn/start`
+
+The wake prompt sent to `turn/start` is still the canonical short prompt:
+
+```text
+WAKE_TRIGGER_ID=<wake-id>
+Resume the scheduled wake task.
+```
+
+## Source Verification
+
+Official docs checked on 2026-05-18:
+
+- App-server supports stdio, WebSocket, Unix socket, and off transports.
+- WebSocket transport is experimental and unsupported.
+- Local WebSocket listeners are appropriate for localhost and SSH forwarding.
+- Non-loopback WebSocket listeners require WebSocket auth before remote exposure.
+
+Local Codex CLI checked on 2026-05-18:
+
+- `codex-cli 0.130.0`
+- `codex app-server --listen stdio://`
+- `codex app-server generate-json-schema --experimental`
+- `codex app-server generate-ts --experimental`
+
+Generated schema confirmed:
+
+- `thread/resume` uses `ThreadResumeParams` with `threadId`.
+- `turn/start` uses `TurnStartParams` with `threadId` and text `input`.
+
+## Safety Boundary
+
+Only `stdio://` is implemented in Codex Wake right now.
+
+WebSocket support is deferred until there is a clear local operator need and a testable auth setup. If implemented, it must enforce one of:
+
+- loopback-only `ws://127.0.0.1:<port>`
+- SSH-forwarded loopback
+- authenticated `wss://` for non-local access
+
+Do not expose unauthenticated non-loopback WebSocket app-server endpoints.

--- a/docs/dev/codex-hooks.example.json
+++ b/docs/dev/codex-hooks.example.json
@@ -1,0 +1,16 @@
+{
+  "hooks": {
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"$(git rev-parse --show-toplevel)/.codex/hooks/wake_user_prompt_submit.py\"",
+            "timeout": 5,
+            "statusMessage": "Checking wake trigger"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/docs/dev/plans/0001-2026-05-18-initial-wake-timer-design.md
+++ b/docs/dev/plans/0001-2026-05-18-initial-wake-timer-design.md
@@ -1,6 +1,6 @@
 # Initial Wake Timer Design
 
-State: OPEN
+State: CLOSED
 Lane: P01
 
 ## Scope
@@ -17,7 +17,7 @@ Design the first durable product shape for a wake spooler that TUI-bound Codex a
 
 ## Current State
 
-The repo has policy and planning scaffolding only. No source tree, package manifest, CLI, runtime state schema, or tests exist yet. The roadmap now records the intended MVP: `codex-wake` CLI, a polling `codex-waked` daemon, tmux injection, and a `UserPromptSubmit` hook ack/context loader.
+The repo has an accepted P01 design artifact at `docs/dev/0001-wake-spooler-design.md`. No source tree, package manifest, CLI, runtime state schema implementation, or tests exist yet.
 
 ## Design Questions
 
@@ -41,4 +41,4 @@ The repo has policy and planning scaffolding only. No source tree, package manif
 
 ## Definition Of Done
 
-This plan can close when a design artifact is added under `docs/dev/` and `ROADMAP.md` is updated with the next implementation slice.
+Closed on 2026-05-18. The next active slice is P02, tracked in `docs/dev/plans/0002-2026-05-18-agent-facing-cli.md`.

--- a/docs/dev/plans/0002-2026-05-18-agent-facing-cli.md
+++ b/docs/dev/plans/0002-2026-05-18-agent-facing-cli.md
@@ -1,0 +1,33 @@
+# Agent-Facing CLI
+
+State: CLOSED
+Lane: P02
+
+## Scope
+
+Implement the first `codex-wake` command-line surface for creating and inspecting declarative wake records.
+
+## Non-Goals
+
+- Do not implement tmux injection in this slice.
+- Do not implement a long-running daemon in this slice.
+- Do not implement app-server transport in this slice.
+- Do not execute commands from trigger records.
+
+## Current State
+
+P01 produced the accepted wake-spooler design in `docs/dev/0001-wake-spooler-design.md`. The repo does not yet have source code, package metadata, tests, or an executable CLI.
+
+## Acceptance Criteria
+
+- `codex-wake after <duration> -- <prompt>` writes a schema-versioned `not_before` wake.
+- `codex-wake at <timestamp> -- <prompt>` writes a schema-versioned `not_before` wake with UTC `due_at`.
+- `codex-wake file <path> -- <prompt>` writes a schema-versioned `file_exists` wake.
+- `codex-wake list` lists active wakes without mutating state.
+- `codex-wake show <wake-id>` prints a wake record.
+- `codex-wake cancel <wake-id>` marks a wake cancelled.
+- Unit tests cover duration parsing, timestamp normalization, wake id generation shape, and JSON schema basics.
+
+## Definition Of Done
+
+Closed on 2026-05-18. The CLI exists, focused tests pass, and `ROADMAP.md` has opened the daemon lane.

--- a/docs/dev/plans/0003-2026-05-18-wake-daemon-trigger-engine.md
+++ b/docs/dev/plans/0003-2026-05-18-wake-daemon-trigger-engine.md
@@ -1,0 +1,33 @@
+# Wake Daemon And Trigger Engine
+
+State: OPEN
+Lane: P03
+
+## Scope
+
+Implement `codex-waked`, a small polling daemon that reads pending wake records, evaluates MVP predicates, and moves records through deterministic status transitions.
+
+## Non-Goals
+
+- Do not implement tmux paste injection in this slice.
+- Do not implement Codex hooks in this slice.
+- Do not implement app-server transport in this slice.
+- Do not implement arbitrary command predicates.
+
+## Current State
+
+The `codex-wake` CLI can create, list, show, and cancel declarative wake records. No daemon evaluates predicates yet.
+
+## Acceptance Criteria
+
+- `codex-waked` polls a wake root.
+- `not_before` records fire when `due_at <= now`.
+- `file_exists` records fire when the referenced path exists relative to the creating cwd unless absolute.
+- Predicate matches append stable event records.
+- Matching records move from `pending` to `firing`.
+- Records with invalid predicates move to `failed` with a clear error.
+- Focused tests cover predicate evaluation and status movement.
+
+## Definition Of Done
+
+The plan can close when `codex-waked` can deterministically move eligible records into `firing` and tests cover both MVP predicates.

--- a/docs/dev/plans/0003-2026-05-18-wake-daemon-trigger-engine.md
+++ b/docs/dev/plans/0003-2026-05-18-wake-daemon-trigger-engine.md
@@ -1,6 +1,6 @@
 # Wake Daemon And Trigger Engine
 
-State: OPEN
+State: CLOSED
 Lane: P03
 
 ## Scope
@@ -30,4 +30,4 @@ The `codex-wake` CLI can create, list, show, and cancel declarative wake records
 
 ## Definition Of Done
 
-The plan can close when `codex-waked` can deterministically move eligible records into `firing` and tests cover both MVP predicates.
+Closed on 2026-05-18. `codex-waked` can deterministically move eligible records into `firing`, invalid predicates into `failed`, and tests cover both MVP predicates.

--- a/docs/dev/plans/0004-2026-05-18-tmux-injection-mvp.md
+++ b/docs/dev/plans/0004-2026-05-18-tmux-injection-mvp.md
@@ -1,0 +1,33 @@
+# Tmux Injection MVP
+
+State: OPEN
+Lane: P04
+
+## Scope
+
+Implement the tmux injector that handles records in `firing` by submitting the canonical wake prompt into the captured Codex TUI pane.
+
+## Non-Goals
+
+- Do not implement the Codex `UserPromptSubmit` hook in this slice.
+- Do not mark records `submitted` without an ack file.
+- Do not implement app-server transport in this slice.
+- Do not paste the full continuation prompt into tmux.
+
+## Current State
+
+`codex-waked` can evaluate pending records and move ready records to `firing`. No injection or ack waiting exists yet.
+
+## Acceptance Criteria
+
+- The injector builds the canonical prompt from wake id only.
+- The injector uses the record's tmux socket and pane target.
+- The injector writes a temporary prompt file or tmux buffer without shell-interpolating prompt text.
+- Unsafe pane heuristics reject obvious non-dispatch states.
+- Per-pane locks prevent concurrent dispatch into the same pane.
+- Missing ack results in a bounded requeue rather than tight retry.
+- Focused tests cover prompt construction, unsafe pane detection, lock behavior, and no-full-prompt injection.
+
+## Definition Of Done
+
+The plan can close when firing records can be safely dispatched to tmux in a dry-run/testable injector path and missing ack behavior is deterministic.

--- a/docs/dev/plans/0004-2026-05-18-tmux-injection-mvp.md
+++ b/docs/dev/plans/0004-2026-05-18-tmux-injection-mvp.md
@@ -1,6 +1,6 @@
 # Tmux Injection MVP
 
-State: OPEN
+State: CLOSED
 Lane: P04
 
 ## Scope
@@ -30,4 +30,4 @@ Implement the tmux injector that handles records in `firing` by submitting the c
 
 ## Definition Of Done
 
-The plan can close when firing records can be safely dispatched to tmux in a dry-run/testable injector path and missing ack behavior is deterministic.
+Closed on 2026-05-18. Firing records can be dispatched through a testable tmux injector path, unsafe panes are rejected, per-pane locks are enforced, and missing ack behavior is deterministic.

--- a/docs/dev/plans/0005-2026-05-18-codex-hook-ack-context-loader.md
+++ b/docs/dev/plans/0005-2026-05-18-codex-hook-ack-context-loader.md
@@ -1,6 +1,6 @@
 # Codex Hook Ack And Context Loader
 
-State: OPEN
+State: CLOSED
 Lane: P05
 
 ## Scope
@@ -29,4 +29,4 @@ The tmux injector can paste canonical wake prompts and waits for `.codex/wake/ac
 
 ## Definition Of Done
 
-The plan can close when the hook can produce ack files and hook-specific JSON output deterministically without depending on a live Codex TUI.
+Closed on 2026-05-18. The hook can produce ack files and hook-specific JSON output deterministically without depending on a live Codex TUI.

--- a/docs/dev/plans/0005-2026-05-18-codex-hook-ack-context-loader.md
+++ b/docs/dev/plans/0005-2026-05-18-codex-hook-ack-context-loader.md
@@ -1,0 +1,32 @@
+# Codex Hook Ack And Context Loader
+
+State: OPEN
+Lane: P05
+
+## Scope
+
+Implement the repo-local Codex `UserPromptSubmit` hook that acknowledges canonical wake prompts and loads full wake context into the turn.
+
+## Non-Goals
+
+- Do not implement app-server transport in this slice.
+- Do not broaden hook behavior beyond `WAKE_TRIGGER_ID=...`.
+- Do not make the hook responsible for timers, polling, or dispatch.
+
+## Current State
+
+The tmux injector can paste canonical wake prompts and waits for `.codex/wake/acks/<wake-id>.submitted`. No hook writes that ack or adds context yet.
+
+## Acceptance Criteria
+
+- `.codex/hooks/wake_user_prompt_submit.py` self-filters for `WAKE_TRIGGER_ID=...`.
+- The hook writes `.codex/wake/acks/<wake-id>.submitted`.
+- The ack includes wake id, submitted timestamp, turn id, and session id when present.
+- If the wake record exists, the hook adds developer context with predicate, original prompt, and evidence/context paths.
+- If the wake record is missing, the hook adds context telling the agent to inspect wake state before continuing.
+- A sample Codex hook config fragment exists.
+- Tests cover no-match, found-record, and missing-record behavior.
+
+## Definition Of Done
+
+The plan can close when the hook can produce ack files and hook-specific JSON output deterministically without depending on a live Codex TUI.

--- a/docs/dev/plans/0006-2026-05-18-runtime-state-retention-safety.md
+++ b/docs/dev/plans/0006-2026-05-18-runtime-state-retention-safety.md
@@ -1,0 +1,31 @@
+# Runtime State, Retention, And Safety
+
+State: OPEN
+Lane: P06
+
+## Scope
+
+Finalize runtime-state layout, retention rules, cleanup behavior, and safety documentation for wake records and ack/log artifacts.
+
+## Non-Goals
+
+- Do not implement app-server transport in this slice.
+- Do not expand trigger types in this slice.
+- Do not store raw private transcripts or credentials in wake records.
+
+## Current State
+
+The CLI creates wake records, the daemon evaluates predicates and dispatches firing records, the tmux injector handles canonical prompt injection, and the Codex hook writes ack files plus wake context. Runtime state exists under `.codex/wake/`, but retention and cleanup semantics are not yet fully specified or implemented.
+
+## Acceptance Criteria
+
+- Runtime-state directories are documented as authoritative, derived, ephemeral, or sensitive.
+- Cleanup/archive behavior is explicit.
+- The CLI exposes safe inspection of active and terminal wakes.
+- A cleanup or archive command exists, or the plan records why it is deferred.
+- Safety documentation states what must never be stored in trigger JSON.
+- Tests cover any implemented cleanup/archive behavior.
+
+## Definition Of Done
+
+The plan can close when operators can understand what wake runtime files mean, what is safe to keep, and how terminal records are retained or archived.

--- a/docs/dev/plans/0006-2026-05-18-runtime-state-retention-safety.md
+++ b/docs/dev/plans/0006-2026-05-18-runtime-state-retention-safety.md
@@ -1,6 +1,6 @@
 # Runtime State, Retention, And Safety
 
-State: OPEN
+State: CLOSED
 Lane: P06
 
 ## Scope
@@ -28,4 +28,4 @@ The CLI creates wake records, the daemon evaluates predicates and dispatches fir
 
 ## Definition Of Done
 
-The plan can close when operators can understand what wake runtime files mean, what is safe to keep, and how terminal records are retained or archived.
+Closed on 2026-05-18. Operators can understand what wake runtime files mean, what is safe to keep, and how terminal records are retained or archived.

--- a/docs/dev/plans/0007-2026-05-18-app-server-controlled-mode.md
+++ b/docs/dev/plans/0007-2026-05-18-app-server-controlled-mode.md
@@ -1,0 +1,30 @@
+# App-Server Controlled Mode
+
+State: OPEN
+Lane: P07
+
+## Scope
+
+Design and implement the app-server transport path for controlled wake dispatch without tmux paste heuristics.
+
+## Non-Goals
+
+- Do not expose app-server over non-local networks without auth and TLS.
+- Do not remove the tmux MVP path in this slice.
+- Do not implement unrelated Codex session-management behavior.
+
+## Current State
+
+The tmux MVP can create wake records, evaluate predicates, inject canonical prompts, observe hook acks, and archive terminal records. App-server controlled mode is only documented as the preferred future transport.
+
+## Acceptance Criteria
+
+- Current Codex app-server request/response contract is verified from official docs or local CLI behavior.
+- Target records can represent app-server transport without breaking tmux records.
+- App-server dispatch is implemented or a precise implementation-blocker note is recorded.
+- Safety boundaries for localhost, SSH forwarding, auth, and TLS are documented.
+- Tests cover app-server target records and dispatch behavior where implementation is possible.
+
+## Definition Of Done
+
+The plan can close when app-server mode has a verified contract and either a working controlled dispatch path or a concrete blocker with next steps.

--- a/docs/dev/plans/0007-2026-05-18-app-server-controlled-mode.md
+++ b/docs/dev/plans/0007-2026-05-18-app-server-controlled-mode.md
@@ -1,6 +1,6 @@
 # App-Server Controlled Mode
 
-State: OPEN
+State: CLOSED
 Lane: P07
 
 ## Scope
@@ -27,4 +27,4 @@ The tmux MVP can create wake records, evaluate predicates, inject canonical prom
 
 ## Definition Of Done
 
-The plan can close when app-server mode has a verified contract and either a working controlled dispatch path or a concrete blocker with next steps.
+Closed on 2026-05-18. App-server mode has a verified contract and a working stdio dispatch path in code. WebSocket dispatch is deferred behind the documented experimental/auth boundary.

--- a/docs/dev/plans/0008-2026-05-18-installed-runtime-verification.md
+++ b/docs/dev/plans/0008-2026-05-18-installed-runtime-verification.md
@@ -1,6 +1,6 @@
 # Installed Runtime Verification
 
-State: OPEN
+State: CLOSED
 Lane: P08
 
 ## Scope
@@ -29,4 +29,4 @@ The feature branch includes CLI creation/inspection/cancel/archive commands, `co
 
 ## Definition Of Done
 
-The plan can close when the installed runtime surface has been verified and the branch is ready for PR review or merge.
+Closed on 2026-05-18. The installed runtime surface has been verified and the branch is ready for PR review.

--- a/docs/dev/plans/0008-2026-05-18-installed-runtime-verification.md
+++ b/docs/dev/plans/0008-2026-05-18-installed-runtime-verification.md
@@ -1,0 +1,32 @@
+# Installed Runtime Verification
+
+State: OPEN
+Lane: P08
+
+## Scope
+
+Verify the installed Codex Wake executable surface end to end from a user/operator perspective.
+
+## Non-Goals
+
+- Do not add new trigger types in this slice.
+- Do not expose app-server WebSocket mode in this slice.
+- Do not merge or release without a clean installed smoke.
+
+## Current State
+
+The feature branch includes CLI creation/inspection/cancel/archive commands, `codex-waked`, tmux injection, Codex hook ack/context loading, and stdio app-server dispatch. Validation has mostly used source-tree and temporary package-target runs.
+
+## Acceptance Criteria
+
+- Installed `codex-wake --help` works.
+- Installed `codex-waked --once --no-dispatch` works.
+- Installed CLI can create, list, cancel, and archive a wake.
+- Installed hook wrapper can write an ack from a JSON payload.
+- A daemon smoke can move an already-due wake to `firing` with `--no-dispatch`.
+- A dry/testable dispatch path is documented for tmux and app-server modes.
+- Any live tmux or app-server limitation is recorded before opening a PR.
+
+## Definition Of Done
+
+The plan can close when the installed runtime surface has been verified and the branch is ready for PR review or merge.

--- a/docs/dev/runtime-state.md
+++ b/docs/dev/runtime-state.md
@@ -1,0 +1,61 @@
+# Runtime State
+
+Codex Wake runtime state lives under `.codex/wake/` by default. This directory is ignored by git and is not a source-controlled product artifact.
+
+## Directory Classes
+
+- `pending/`: authoritative active wake records awaiting predicate match.
+- `firing/`: authoritative active wake records currently being dispatched or awaiting ack.
+- `submitted/`: terminal wake records with observed hook ack.
+- `failed/`: terminal wake records that could not be completed.
+- `cancelled/`: terminal wake records cancelled by an operator.
+- `expired/`: terminal wake records that exceeded an expiry policy.
+- `acks/`: derived ack files written by the Codex hook.
+- `logs/`: ephemeral operational logs.
+- `locks/`: ephemeral pane lock files.
+- `archive/`: retained terminal wake records moved out of active status directories.
+
+## Retention Rules
+
+- Active records in `pending/` and `firing/` must not be archived.
+- Terminal records in `submitted/`, `failed/`, `cancelled/`, and `expired/` may be archived.
+- Archiving preserves the JSON record, appends an `archived` event, sets `previous_status`, and moves the record to `archive/`.
+- `acks/` are derived evidence. They may be retained while debugging, but the authoritative wake outcome is the wake record.
+- `logs/` and `locks/` are operational artifacts and should not be treated as durable source of truth.
+
+## Safety Rules
+
+Wake records must not contain:
+
+- raw credentials or API keys
+- raw private transcripts
+- shell commands to execute
+- broad dumps of private user data
+
+Use paths and short task context instead of embedding large private content. A wake should point the resumed agent at logs, event files, or review artifacts that are already appropriate for the workspace.
+
+## Commands
+
+List active wakes:
+
+```bash
+codex-wake list
+```
+
+List active and archived wakes:
+
+```bash
+codex-wake list --archived
+```
+
+Archive one terminal wake:
+
+```bash
+codex-wake archive wake_20260518_153000_9f3a
+```
+
+Archive all terminal wakes:
+
+```bash
+codex-wake archive --all-terminal
+```

--- a/docs/dev/verification/0001-2026-05-18-installed-runtime-verification.md
+++ b/docs/dev/verification/0001-2026-05-18-installed-runtime-verification.md
@@ -1,0 +1,117 @@
+# Installed Runtime Verification
+
+Date: 2026-05-18
+Branch: `p02-agent-facing-cli`
+
+## Environment
+
+- Python virtualenv: `/tmp/codex-wake-venv`
+- Install command: `/tmp/codex-wake-venv/bin/python -m pip install .`
+- Smoke roots:
+  - `/tmp/codex-wake-installed-smoke`
+  - `/tmp/codex-wake-daemon-installed`
+  - `/tmp/codex-wake-app-installed`
+
+## Commands Verified
+
+```bash
+/tmp/codex-wake-venv/bin/codex-wake --help
+/tmp/codex-wake-venv/bin/codex-waked --once --no-dispatch --wake-root /tmp/codex-wake-installed-smoke
+```
+
+Result:
+
+```text
+checked=0 fired=0 failed=0 pending=0 dispatched=0 submitted=0 requeued=0
+```
+
+## CLI Lifecycle Smoke
+
+```bash
+TMUX_PANE='%11' TMUX='/tmp/tmux-1000/default,123,0' \
+  /tmp/codex-wake-venv/bin/codex-wake --wake-root /tmp/codex-wake-installed-smoke \
+  file .codex/events/pytest.done -- 'Read pytest log'
+
+/tmp/codex-wake-venv/bin/codex-wake --wake-root /tmp/codex-wake-installed-smoke list
+/tmp/codex-wake-venv/bin/codex-wake --wake-root /tmp/codex-wake-installed-smoke cancel <wake-id>
+/tmp/codex-wake-venv/bin/codex-wake --wake-root /tmp/codex-wake-installed-smoke archive <wake-id>
+```
+
+Observed:
+
+```text
+ID	STATUS	PREDICATE	NEXT
+<wake-id>	pending	file_exists	<timestamp>
+cancelled <wake-id> ...
+archived <wake-id> ...
+```
+
+## Daemon Predicate Smoke
+
+```bash
+TMUX_PANE='%11' TMUX='/tmp/tmux-1000/default,123,0' \
+  /tmp/codex-wake-venv/bin/codex-wake --wake-root /tmp/codex-wake-daemon-installed \
+  at '2026-05-18T00:00:00Z' -- 'Due wake'
+
+/tmp/codex-wake-venv/bin/codex-waked --wake-root /tmp/codex-wake-daemon-installed --once --no-dispatch
+```
+
+Observed:
+
+```text
+checked=1 fired=1 failed=0 pending=0 dispatched=0 submitted=0 requeued=0
+/tmp/codex-wake-daemon-installed/firing/<wake-id>.json
+```
+
+## Hook Smoke
+
+```bash
+python -c 'import json, sys; print(json.dumps({"prompt":"WAKE_TRIGGER_ID=wake_installed\nResume","cwd":sys.argv[1],"turn_id":"turn_installed","session_id":"session_installed"}))' "$tmp" \
+  | ./.codex/hooks/wake_user_prompt_submit.py
+```
+
+Observed:
+
+```json
+{
+  "hookSpecificOutput": {
+    "additionalContext": "Wake trigger wake_installed was submitted, but its trigger file was not found. Inspect .codex/wake before continuing, and ask the user if the wake state is ambiguous.",
+    "hookEventName": "UserPromptSubmit"
+  }
+}
+```
+
+Ack file written:
+
+```json
+{
+  "session_id": "session_installed",
+  "turn_id": "turn_installed",
+  "wake_id": "wake_installed"
+}
+```
+
+## App-Server Target Smoke
+
+```bash
+/tmp/codex-wake-venv/bin/codex-wake --wake-root /tmp/codex-wake-app-installed \
+  after --app-server-thread-id thread_installed 1m -- 'App server installed smoke'
+
+/tmp/codex-wake-venv/bin/codex-wake --wake-root /tmp/codex-wake-app-installed list --json
+```
+
+Observed target:
+
+```json
+{
+  "endpoint": "stdio://",
+  "thread_id": "thread_installed",
+  "transport": "app-server"
+}
+```
+
+## Limitations
+
+- Live tmux dispatch was not attempted because this smoke did not create a disposable Codex TUI pane target. The injector path is covered by focused tests with a fake tmux runner.
+- Live app-server `thread/resume` plus `turn/start` was not attempted against a real Codex thread id. The stdio app-server payload path is covered by focused tests with a fake app-server client, and target record creation is installed-smoked.
+- WebSocket app-server dispatch remains intentionally unimplemented because official docs mark it experimental and unsupported; non-loopback use requires auth and TLS.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,21 @@
+[build-system]
+requires = ["setuptools>=68"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "codex-wake"
+version = "0.1.0"
+description = "Local wake spooler for TUI-bound Codex agents"
+readme = "README.md"
+requires-python = ">=3.11"
+license = { text = "MIT" }
+authors = [
+  { name = "Cochran Research Group" }
+]
+dependencies = []
+
+[project.scripts]
+codex-wake = "codex_wake.cli:main"
+
+[tool.setuptools.packages.find]
+where = ["src"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = []
 
 [project.scripts]
 codex-wake = "codex_wake.cli:main"
+codex-waked = "codex_wake.daemon:main"
 
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/src/codex_wake/__init__.py
+++ b/src/codex_wake/__init__.py
@@ -1,0 +1,5 @@
+"""Codex Wake package."""
+
+__all__ = ["__version__"]
+
+__version__ = "0.1.0"

--- a/src/codex_wake/__main__.py
+++ b/src/codex_wake/__main__.py
@@ -1,0 +1,5 @@
+from .cli import main
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/codex_wake/app_server.py
+++ b/src/codex_wake/app_server.py
@@ -1,0 +1,164 @@
+from __future__ import annotations
+
+import json
+import subprocess
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Protocol
+
+from .injector import canonical_prompt
+from .records import WakeError, WakePath, append_event, format_utc, replace_record, utc_now
+
+
+class AppServerClient(Protocol):
+    def initialize(self) -> dict[str, Any]:
+        ...
+
+    def resume_thread(self, thread_id: str, cwd: str | None = None) -> dict[str, Any]:
+        ...
+
+    def start_turn(self, thread_id: str, prompt: str, cwd: str | None = None) -> dict[str, Any]:
+        ...
+
+    def close(self) -> None:
+        ...
+
+
+@dataclass(frozen=True)
+class AppServerDispatchResult:
+    status: str
+    message: str
+
+
+class StdioAppServerClient:
+    def __init__(self, command: list[str] | None = None, timeout_seconds: float = 30.0) -> None:
+        self.command = command or ["codex", "app-server", "--listen", "stdio://"]
+        self.timeout_seconds = timeout_seconds
+        self._next_id = 1
+        self.process = subprocess.Popen(
+            self.command,
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+
+    def close(self) -> None:
+        if self.process.poll() is None:
+            self.process.terminate()
+            try:
+                self.process.wait(timeout=2)
+            except subprocess.TimeoutExpired:
+                self.process.kill()
+
+    def request(self, method: str, params: dict[str, Any]) -> dict[str, Any]:
+        if self.process.stdin is None or self.process.stdout is None:
+            raise WakeError("app-server stdio pipes are unavailable")
+        request_id = self._next_id
+        self._next_id += 1
+        payload = {
+            "jsonrpc": "2.0",
+            "id": request_id,
+            "method": method,
+            "params": params,
+        }
+        self.process.stdin.write(json.dumps(payload) + "\n")
+        self.process.stdin.flush()
+        while True:
+            line = self.process.stdout.readline()
+            if not line:
+                raise WakeError(f"app-server closed stdout while waiting for {method}")
+            message = json.loads(line)
+            if message.get("id") != request_id:
+                continue
+            if "error" in message:
+                raise WakeError(f"app-server {method} failed: {message['error']}")
+            result = message.get("result")
+            if not isinstance(result, dict):
+                raise WakeError(f"app-server {method} returned non-object result")
+            return result
+
+    def initialize(self) -> dict[str, Any]:
+        return self.request(
+            "initialize",
+            {
+                "clientInfo": {
+                    "name": "codex-wake",
+                    "title": "Codex Wake",
+                    "version": "0.1.0",
+                },
+                "capabilities": {"experimentalApi": True},
+            },
+        )
+
+    def resume_thread(self, thread_id: str, cwd: str | None = None) -> dict[str, Any]:
+        params: dict[str, Any] = {"threadId": thread_id, "persistExtendedHistory": False}
+        if cwd:
+            params["cwd"] = cwd
+        return self.request("thread/resume", params)
+
+    def start_turn(self, thread_id: str, prompt: str, cwd: str | None = None) -> dict[str, Any]:
+        params: dict[str, Any] = {
+            "threadId": thread_id,
+            "input": [{"type": "text", "text": prompt, "text_elements": []}],
+        }
+        if cwd:
+            params["cwd"] = cwd
+        return self.request("turn/start", params)
+
+
+def app_server_target(record: dict[str, Any]) -> dict[str, Any]:
+    target = record.get("target")
+    if not isinstance(target, dict):
+        raise WakeError("record target must be an object")
+    if target.get("transport") != "app-server":
+        raise WakeError(f"unsupported target transport: {target.get('transport')}")
+    endpoint = target.get("endpoint", "stdio://")
+    if endpoint != "stdio://":
+        raise WakeError("only app-server stdio:// transport is implemented")
+    thread_id = target.get("thread_id")
+    if not isinstance(thread_id, str) or not thread_id:
+        raise WakeError("app-server target requires thread_id")
+    return target
+
+
+def dispatch_app_server_record(
+    root: Path,
+    found: WakePath,
+    *,
+    client: AppServerClient | None = None,
+    now: datetime | None = None,
+) -> AppServerDispatchResult:
+    current = now or utc_now()
+    record = dict(found.record)
+    if record.get("status") != "firing":
+        return AppServerDispatchResult("skipped", "record is not firing")
+    wake_id = record.get("id")
+    if not isinstance(wake_id, str) or not wake_id:
+        raise WakeError("wake record missing id")
+    try:
+        target = app_server_target(record)
+        thread_id = target["thread_id"]
+        cwd = record.get("cwd") if isinstance(record.get("cwd"), str) else None
+        app_client = client or StdioAppServerClient(command=target.get("command"))
+        try:
+            app_client.initialize()
+            app_client.resume_thread(thread_id, cwd=cwd)
+            app_client.start_turn(thread_id, canonical_prompt(wake_id), cwd=cwd)
+        finally:
+            if client is None:
+                app_client.close()
+    except WakeError as exc:
+        record["status"] = "failed"
+        record["updated_at"] = format_utc(current)
+        record["last_error"] = str(exc)
+        record = append_event(record, "failed", str(exc), current)
+        replace_record(root, found, record)
+        return AppServerDispatchResult("failed", str(exc))
+    record["status"] = "submitted"
+    record["updated_at"] = format_utc(current)
+    record = append_event(record, "dispatch_attempt", "Starting app-server wake turn", current)
+    record = append_event(record, "ack_observed", "App-server turn/start accepted wake prompt", current)
+    replace_record(root, found, record)
+    return AppServerDispatchResult("submitted", "turn/start accepted")

--- a/src/codex_wake/cli.py
+++ b/src/codex_wake/cli.py
@@ -1,0 +1,157 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import UTC
+from pathlib import Path
+
+from .records import (
+    WakeError,
+    build_record,
+    cancel_record,
+    capture_tmux_target,
+    default_wake_root,
+    find_record,
+    format_utc,
+    iter_records,
+    normalize_prompt,
+    parse_duration,
+    parse_timestamp,
+    utc_now,
+    write_record,
+)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="codex-wake")
+    parser.add_argument(
+        "--wake-root",
+        type=Path,
+        default=None,
+        help="wake runtime root; defaults to .codex/wake under the current directory",
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    after = subparsers.add_parser("after", help="create a wake after a duration such as 45m or 1h30m")
+    after.add_argument("duration")
+    after.add_argument("prompt", nargs=argparse.REMAINDER)
+
+    at = subparsers.add_parser("at", help="create a wake at an ISO-8601 timestamp with timezone")
+    at.add_argument("timestamp")
+    at.add_argument("prompt", nargs=argparse.REMAINDER)
+
+    file_cmd = subparsers.add_parser("file", help="create a wake when a file exists")
+    file_cmd.add_argument("path")
+    file_cmd.add_argument("prompt", nargs=argparse.REMAINDER)
+
+    list_cmd = subparsers.add_parser("list", help="list wake records")
+    list_cmd.add_argument("--json", action="store_true", dest="as_json")
+
+    show = subparsers.add_parser("show", help="show one wake record")
+    show.add_argument("wake_id")
+
+    cancel = subparsers.add_parser("cancel", help="cancel a pending or firing wake")
+    cancel.add_argument("wake_id")
+
+    return parser
+
+
+def resolve_root(args: argparse.Namespace) -> Path:
+    return (args.wake_root or default_wake_root()).resolve()
+
+
+def create_after(args: argparse.Namespace, root: Path) -> int:
+    now = utc_now()
+    due = now + parse_duration(args.duration)
+    predicate = {"type": "not_before", "due_at": format_utc(due)}
+    return create_record(args.prompt, predicate, root, now)
+
+
+def create_at(args: argparse.Namespace, root: Path) -> int:
+    due = parse_timestamp(args.timestamp)
+    predicate = {"type": "not_before", "due_at": format_utc(due)}
+    return create_record(args.prompt, predicate, root, utc_now())
+
+
+def create_file(args: argparse.Namespace, root: Path) -> int:
+    path = args.path.strip()
+    if not path:
+        raise WakeError("file path is required")
+    predicate = {"type": "file_exists", "path": path}
+    return create_record(args.prompt, predicate, root, utc_now())
+
+
+def create_record(prompt_parts: list[str], predicate: dict[str, str], root: Path, now) -> int:
+    prompt = normalize_prompt(prompt_parts)
+    record = build_record(
+        predicate=predicate,
+        prompt=prompt,
+        cwd=Path.cwd(),
+        target=capture_tmux_target(),
+        now=now,
+    )
+    path = write_record(root, record)
+    print(f"{record['id']} {path}")
+    return 0
+
+
+def list_records(args: argparse.Namespace, root: Path) -> int:
+    records = iter_records(root)
+    if args.as_json:
+        print(json.dumps([item.record for item in records], indent=2, sort_keys=True))
+        return 0
+    if not records:
+        print("No wakes.")
+        return 0
+    print("ID\tSTATUS\tPREDICATE\tNEXT")
+    for item in records:
+        record = item.record
+        predicate = record.get("predicate") or {}
+        predicate_type = predicate.get("type", "unknown")
+        next_attempt = record.get("next_attempt_at", "")
+        print(f"{record.get('id')}\t{record.get('status')}\t{predicate_type}\t{next_attempt}")
+    return 0
+
+
+def show_record(args: argparse.Namespace, root: Path) -> int:
+    found = find_record(root, args.wake_id)
+    print(json.dumps(found.record, indent=2, sort_keys=True))
+    return 0
+
+
+def cancel(args: argparse.Namespace, root: Path) -> int:
+    path = cancel_record(root, args.wake_id)
+    print(f"cancelled {args.wake_id} {path}")
+    return 0
+
+
+def run(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    root = resolve_root(args)
+    if args.command == "after":
+        return create_after(args, root)
+    if args.command == "at":
+        return create_at(args, root)
+    if args.command == "file":
+        return create_file(args, root)
+    if args.command == "list":
+        return list_records(args, root)
+    if args.command == "show":
+        return show_record(args, root)
+    if args.command == "cancel":
+        return cancel(args, root)
+    raise WakeError(f"unknown command: {args.command}")
+
+
+def main(argv: list[str] | None = None) -> int:
+    try:
+        return run(argv)
+    except WakeError as exc:
+        print(f"codex-wake: {exc}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/codex_wake/cli.py
+++ b/src/codex_wake/cli.py
@@ -8,6 +8,9 @@ from pathlib import Path
 
 from .records import (
     WakeError,
+    all_records,
+    archive_record,
+    archive_terminal_records,
     build_record,
     cancel_record,
     capture_tmux_target,
@@ -47,12 +50,17 @@ def build_parser() -> argparse.ArgumentParser:
 
     list_cmd = subparsers.add_parser("list", help="list wake records")
     list_cmd.add_argument("--json", action="store_true", dest="as_json")
+    list_cmd.add_argument("--archived", action="store_true", help="include archived wake records")
 
     show = subparsers.add_parser("show", help="show one wake record")
     show.add_argument("wake_id")
 
     cancel = subparsers.add_parser("cancel", help="cancel a pending or firing wake")
     cancel.add_argument("wake_id")
+
+    archive = subparsers.add_parser("archive", help="archive terminal wake records")
+    archive.add_argument("wake_id", nargs="?", help="specific wake id to archive")
+    archive.add_argument("--all-terminal", action="store_true", help="archive all submitted, failed, cancelled, and expired wakes")
 
     return parser
 
@@ -97,7 +105,7 @@ def create_record(prompt_parts: list[str], predicate: dict[str, str], root: Path
 
 
 def list_records(args: argparse.Namespace, root: Path) -> int:
-    records = iter_records(root)
+    records = all_records(root, include_archive=args.archived)
     if args.as_json:
         print(json.dumps([item.record for item in records], indent=2, sort_keys=True))
         return 0
@@ -126,6 +134,21 @@ def cancel(args: argparse.Namespace, root: Path) -> int:
     return 0
 
 
+def archive(args: argparse.Namespace, root: Path) -> int:
+    if bool(args.wake_id) == bool(args.all_terminal):
+        raise WakeError("provide either a wake id or --all-terminal")
+    if args.all_terminal:
+        paths = archive_terminal_records(root)
+        for path in paths:
+            print(f"archived {path.stem} {path}")
+        if not paths:
+            print("No terminal wakes to archive.")
+        return 0
+    path = archive_record(root, args.wake_id)
+    print(f"archived {args.wake_id} {path}")
+    return 0
+
+
 def run(argv: list[str] | None = None) -> int:
     parser = build_parser()
     args = parser.parse_args(argv)
@@ -142,6 +165,8 @@ def run(argv: list[str] | None = None) -> int:
         return show_record(args, root)
     if args.command == "cancel":
         return cancel(args, root)
+    if args.command == "archive":
+        return archive(args, root)
     raise WakeError(f"unknown command: {args.command}")
 
 

--- a/src/codex_wake/cli.py
+++ b/src/codex_wake/cli.py
@@ -39,14 +39,17 @@ def build_parser() -> argparse.ArgumentParser:
     after = subparsers.add_parser("after", help="create a wake after a duration such as 45m or 1h30m")
     after.add_argument("duration")
     after.add_argument("prompt", nargs=argparse.REMAINDER)
+    add_target_options(after)
 
     at = subparsers.add_parser("at", help="create a wake at an ISO-8601 timestamp with timezone")
     at.add_argument("timestamp")
     at.add_argument("prompt", nargs=argparse.REMAINDER)
+    add_target_options(at)
 
     file_cmd = subparsers.add_parser("file", help="create a wake when a file exists")
     file_cmd.add_argument("path")
     file_cmd.add_argument("prompt", nargs=argparse.REMAINDER)
+    add_target_options(file_cmd)
 
     list_cmd = subparsers.add_parser("list", help="list wake records")
     list_cmd.add_argument("--json", action="store_true", dest="as_json")
@@ -65,6 +68,18 @@ def build_parser() -> argparse.ArgumentParser:
     return parser
 
 
+def add_target_options(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
+        "--app-server-thread-id",
+        help="create an app-server-targeted wake for the given Codex thread id instead of capturing tmux",
+    )
+    parser.add_argument(
+        "--app-server-endpoint",
+        default="stdio://",
+        help="app-server endpoint for --app-server-thread-id; only stdio:// is currently implemented",
+    )
+
+
 def resolve_root(args: argparse.Namespace) -> Path:
     return (args.wake_root or default_wake_root()).resolve()
 
@@ -73,13 +88,13 @@ def create_after(args: argparse.Namespace, root: Path) -> int:
     now = utc_now()
     due = now + parse_duration(args.duration)
     predicate = {"type": "not_before", "due_at": format_utc(due)}
-    return create_record(args.prompt, predicate, root, now)
+    return create_record(args.prompt, predicate, root, now, args)
 
 
 def create_at(args: argparse.Namespace, root: Path) -> int:
     due = parse_timestamp(args.timestamp)
     predicate = {"type": "not_before", "due_at": format_utc(due)}
-    return create_record(args.prompt, predicate, root, utc_now())
+    return create_record(args.prompt, predicate, root, utc_now(), args)
 
 
 def create_file(args: argparse.Namespace, root: Path) -> int:
@@ -87,21 +102,34 @@ def create_file(args: argparse.Namespace, root: Path) -> int:
     if not path:
         raise WakeError("file path is required")
     predicate = {"type": "file_exists", "path": path}
-    return create_record(args.prompt, predicate, root, utc_now())
+    return create_record(args.prompt, predicate, root, utc_now(), args)
 
 
-def create_record(prompt_parts: list[str], predicate: dict[str, str], root: Path, now) -> int:
+def create_record(prompt_parts: list[str], predicate: dict[str, str], root: Path, now, args: argparse.Namespace) -> int:
     prompt = normalize_prompt(prompt_parts)
     record = build_record(
         predicate=predicate,
         prompt=prompt,
         cwd=Path.cwd(),
-        target=capture_tmux_target(),
+        target=target_for_args(args),
         now=now,
     )
     path = write_record(root, record)
     print(f"{record['id']} {path}")
     return 0
+
+
+def target_for_args(args: argparse.Namespace) -> dict[str, str]:
+    if getattr(args, "app_server_thread_id", None):
+        endpoint = getattr(args, "app_server_endpoint", "stdio://")
+        if endpoint != "stdio://":
+            raise WakeError("only app-server endpoint stdio:// is currently implemented")
+        return {
+            "transport": "app-server",
+            "endpoint": endpoint,
+            "thread_id": args.app_server_thread_id,
+        }
+    return capture_tmux_target()
 
 
 def list_records(args: argparse.Namespace, root: Path) -> int:

--- a/src/codex_wake/daemon.py
+++ b/src/codex_wake/daemon.py
@@ -16,6 +16,7 @@ from .records import (
     parse_utc_timestamp,
     utc_now,
 )
+from .injector import TmuxRunner, dispatch_firing_record
 
 
 @dataclass(frozen=True)
@@ -24,10 +25,17 @@ class PollResult:
     fired: int = 0
     failed: int = 0
     pending: int = 0
+    dispatched: int = 0
+    requeued: int = 0
+    submitted: int = 0
 
 
 def pending_records(root: Path) -> list[WakePath]:
     return [item for item in iter_records(root) if item.record.get("status") == "pending"]
+
+
+def firing_records(root: Path) -> list[WakePath]:
+    return [item for item in iter_records(root) if item.record.get("status") == "firing"]
 
 
 def predicate_is_ready(record: dict, now: datetime) -> tuple[bool, str]:
@@ -54,9 +62,16 @@ def predicate_is_ready(record: dict, now: datetime) -> tuple[bool, str]:
     raise WakeError(f"unsupported predicate type: {predicate_type}")
 
 
-def poll_once(root: Path, now: datetime | None = None) -> PollResult:
+def poll_once(
+    root: Path,
+    now: datetime | None = None,
+    *,
+    dispatch: bool = True,
+    runner: TmuxRunner | None = None,
+    ack_timeout_override: float | None = None,
+) -> PollResult:
     current = now or utc_now()
-    checked = fired = failed = pending = 0
+    checked = fired = failed = pending = dispatched = requeued = submitted = 0
     for item in pending_records(root):
         checked += 1
         try:
@@ -85,7 +100,31 @@ def poll_once(root: Path, now: datetime | None = None) -> PollResult:
             fired += 1
         else:
             pending += 1
-    return PollResult(checked=checked, fired=fired, failed=failed, pending=pending)
+    if dispatch:
+        for item in firing_records(root):
+            dispatched += 1
+            result = dispatch_firing_record(
+                root,
+                item,
+                runner=runner,
+                now=current,
+                ack_timeout_override=ack_timeout_override,
+            )
+            if result.status == "submitted":
+                submitted += 1
+            elif result.status == "requeued":
+                requeued += 1
+            elif result.status == "failed":
+                failed += 1
+    return PollResult(
+        checked=checked,
+        fired=fired,
+        failed=failed,
+        pending=pending,
+        dispatched=dispatched,
+        requeued=requeued,
+        submitted=submitted,
+    )
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -98,6 +137,13 @@ def build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument("--once", action="store_true", help="run one polling pass and exit")
     parser.add_argument("--interval", type=float, default=5.0, help="poll interval in seconds")
+    parser.add_argument("--no-dispatch", action="store_true", help="evaluate predicates but do not dispatch firing records")
+    parser.add_argument(
+        "--ack-timeout",
+        type=float,
+        default=None,
+        help="override ack wait timeout in seconds",
+    )
     return parser
 
 
@@ -106,16 +152,17 @@ def run(argv: list[str] | None = None) -> int:
     args = parser.parse_args(argv)
     root = (args.wake_root or default_wake_root()).resolve()
     if args.once:
-        result = poll_once(root)
+        result = poll_once(root, dispatch=not args.no_dispatch, ack_timeout_override=args.ack_timeout)
         print(
             f"checked={result.checked} fired={result.fired} "
-            f"failed={result.failed} pending={result.pending}"
+            f"failed={result.failed} pending={result.pending} "
+            f"dispatched={result.dispatched} submitted={result.submitted} requeued={result.requeued}"
         )
         return 0
     if args.interval <= 0:
         raise WakeError("--interval must be greater than zero")
     while True:
-        poll_once(root)
+        poll_once(root, dispatch=not args.no_dispatch, ack_timeout_override=args.ack_timeout)
         time.sleep(args.interval)
 
 

--- a/src/codex_wake/daemon.py
+++ b/src/codex_wake/daemon.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+import argparse
+import sys
+import time
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+
+from .records import (
+    WakeError,
+    WakePath,
+    default_wake_root,
+    iter_records,
+    move_record,
+    parse_utc_timestamp,
+    utc_now,
+)
+
+
+@dataclass(frozen=True)
+class PollResult:
+    checked: int = 0
+    fired: int = 0
+    failed: int = 0
+    pending: int = 0
+
+
+def pending_records(root: Path) -> list[WakePath]:
+    return [item for item in iter_records(root) if item.record.get("status") == "pending"]
+
+
+def predicate_is_ready(record: dict, now: datetime) -> tuple[bool, str]:
+    predicate = record.get("predicate")
+    if not isinstance(predicate, dict):
+        raise WakeError("predicate must be an object")
+    predicate_type = predicate.get("type")
+    if predicate_type == "not_before":
+        due_at = predicate.get("due_at")
+        if not isinstance(due_at, str) or not due_at:
+            raise WakeError("not_before predicate requires due_at")
+        return parse_utc_timestamp(due_at) <= now, f"not_before due_at {due_at} matched"
+    if predicate_type == "file_exists":
+        raw_path = predicate.get("path")
+        if not isinstance(raw_path, str) or not raw_path:
+            raise WakeError("file_exists predicate requires path")
+        path = Path(raw_path)
+        if not path.is_absolute():
+            cwd = record.get("cwd")
+            if not isinstance(cwd, str) or not cwd:
+                raise WakeError("relative file_exists predicate requires record cwd")
+            path = Path(cwd) / path
+        return path.exists(), f"file_exists path {path} matched"
+    raise WakeError(f"unsupported predicate type: {predicate_type}")
+
+
+def poll_once(root: Path, now: datetime | None = None) -> PollResult:
+    current = now or utc_now()
+    checked = fired = failed = pending = 0
+    for item in pending_records(root):
+        checked += 1
+        try:
+            ready, message = predicate_is_ready(item.record, current)
+        except WakeError as exc:
+            move_record(
+                root,
+                item,
+                "failed",
+                event_type="failed",
+                message=str(exc),
+                now=current,
+                last_error=str(exc),
+            )
+            failed += 1
+            continue
+        if ready:
+            move_record(
+                root,
+                item,
+                "firing",
+                event_type="predicate_matched",
+                message=message,
+                now=current,
+            )
+            fired += 1
+        else:
+            pending += 1
+    return PollResult(checked=checked, fired=fired, failed=failed, pending=pending)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="codex-waked")
+    parser.add_argument(
+        "--wake-root",
+        type=Path,
+        default=None,
+        help="wake runtime root; defaults to .codex/wake under the current directory",
+    )
+    parser.add_argument("--once", action="store_true", help="run one polling pass and exit")
+    parser.add_argument("--interval", type=float, default=5.0, help="poll interval in seconds")
+    return parser
+
+
+def run(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    root = (args.wake_root or default_wake_root()).resolve()
+    if args.once:
+        result = poll_once(root)
+        print(
+            f"checked={result.checked} fired={result.fired} "
+            f"failed={result.failed} pending={result.pending}"
+        )
+        return 0
+    if args.interval <= 0:
+        raise WakeError("--interval must be greater than zero")
+    while True:
+        poll_once(root)
+        time.sleep(args.interval)
+
+
+def main(argv: list[str] | None = None) -> int:
+    try:
+        return run(argv)
+    except WakeError as exc:
+        print(f"codex-waked: {exc}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/codex_wake/hook.py
+++ b/src/codex_wake/hook.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+import json
+import re
+import sys
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+
+WAKE_ID_RE = re.compile(r"\bWAKE_TRIGGER_ID=([A-Za-z0-9_.:-]+)\b")
+
+
+def utc_timestamp() -> str:
+    return datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def extract_wake_id(prompt: str) -> str | None:
+    match = WAKE_ID_RE.search(prompt)
+    return match.group(1) if match else None
+
+
+def wake_root_for_payload(payload: dict[str, Any]) -> Path:
+    cwd = Path(payload.get("cwd") or ".").resolve()
+    return cwd / ".codex" / "wake"
+
+
+def find_trigger_path(wake_root: Path, wake_id: str) -> Path | None:
+    for status in ("firing", "pending", "submitted", "failed", "cancelled", "expired"):
+        path = wake_root / status / f"{wake_id}.json"
+        if path.exists():
+            return path
+    return None
+
+
+def write_ack(wake_root: Path, wake_id: str, payload: dict[str, Any]) -> Path:
+    ack_path = wake_root / "acks" / f"{wake_id}.submitted"
+    ack_path.parent.mkdir(parents=True, exist_ok=True)
+    ack = {
+        "wake_id": wake_id,
+        "submitted_at": utc_timestamp(),
+        "turn_id": payload.get("turn_id"),
+        "session_id": payload.get("session_id"),
+    }
+    ack_path.write_text(json.dumps(ack, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return ack_path
+
+
+def additional_context_for_trigger(wake_id: str, trigger: dict[str, Any]) -> str:
+    predicate = json.dumps(trigger.get("predicate"), indent=2, sort_keys=True)
+    context_paths = trigger.get("context_paths") or []
+    evidence_paths = trigger.get("evidence_paths") or []
+    return (
+        "A scheduled wake trigger fired.\n\n"
+        f"Wake id: {wake_id}\n"
+        f"Predicate:\n{predicate}\n\n"
+        f"Original wake prompt:\n{trigger.get('prompt', '')}\n\n"
+        f"Context paths: {json.dumps(context_paths, sort_keys=True)}\n"
+        f"Evidence paths: {json.dumps(evidence_paths, sort_keys=True)}\n\n"
+        "Before editing files, verify the predicate is still true and inspect any referenced logs, "
+        "event files, context paths, or evidence paths. If the task is already complete, report that "
+        "and stop."
+    )
+
+
+def missing_trigger_context(wake_id: str) -> str:
+    return (
+        f"Wake trigger {wake_id} was submitted, but its trigger file was not found. "
+        "Inspect .codex/wake before continuing, and ask the user if the wake state is ambiguous."
+    )
+
+
+def hook_output(additional_context: str) -> dict[str, Any]:
+    return {
+        "hookSpecificOutput": {
+            "hookEventName": "UserPromptSubmit",
+            "additionalContext": additional_context,
+        }
+    }
+
+
+def handle_payload(payload: dict[str, Any]) -> dict[str, Any] | None:
+    prompt = payload.get("prompt") or ""
+    if not isinstance(prompt, str):
+        return None
+    wake_id = extract_wake_id(prompt)
+    if not wake_id:
+        return None
+    wake_root = wake_root_for_payload(payload)
+    write_ack(wake_root, wake_id, payload)
+    trigger_path = find_trigger_path(wake_root, wake_id)
+    if trigger_path is None:
+        return hook_output(missing_trigger_context(wake_id))
+    try:
+        trigger = json.loads(trigger_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError:
+        return hook_output(
+            f"Wake trigger {wake_id} was submitted, but its trigger file is not valid JSON. "
+            "Inspect .codex/wake before continuing."
+        )
+    return hook_output(additional_context_for_trigger(wake_id, trigger))
+
+
+def main(argv: list[str] | None = None) -> int:
+    try:
+        payload = json.load(sys.stdin)
+    except json.JSONDecodeError as exc:
+        print(f"codex-wake hook: invalid JSON input: {exc}", file=sys.stderr)
+        return 2
+    output = handle_payload(payload)
+    if output is not None:
+        print(json.dumps(output, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/codex_wake/injector.py
+++ b/src/codex_wake/injector.py
@@ -176,6 +176,12 @@ def dispatch_firing_record(
     wake_id = record.get("id")
     if not isinstance(wake_id, str) or not wake_id:
         raise WakeError("wake record missing id")
+    target = record.get("target")
+    if isinstance(target, dict) and target.get("transport") == "app-server":
+        from .app_server import dispatch_app_server_record
+
+        result = dispatch_app_server_record(root, found, now=current)
+        return DispatchResult(result.status, result.message)
     try:
         socket, pane = target_from_record(record)
     except WakeError as exc:

--- a/src/codex_wake/injector.py
+++ b/src/codex_wake/injector.py
@@ -1,0 +1,246 @@
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+import tempfile
+import time
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import Protocol
+
+from .records import (
+    WakeError,
+    WakePath,
+    append_event,
+    format_utc,
+    replace_record,
+    utc_now,
+)
+
+
+DEFAULT_BACKOFF_SECONDS = (60, 300)
+
+
+@dataclass(frozen=True)
+class DispatchResult:
+    status: str
+    message: str
+
+
+class TmuxRunner(Protocol):
+    def capture_pane(self, socket: str, pane: str) -> str:
+        ...
+
+    def paste_prompt(self, socket: str, pane: str, wake_id: str, prompt: str) -> None:
+        ...
+
+
+class SubprocessTmuxRunner:
+    def capture_pane(self, socket: str, pane: str) -> str:
+        result = subprocess.run(
+            ["tmux", "-S", socket, "capture-pane", "-p", "-t", pane],
+            check=True,
+            text=True,
+            capture_output=True,
+        )
+        return result.stdout
+
+    def paste_prompt(self, socket: str, pane: str, wake_id: str, prompt: str) -> None:
+        buffer_name = f"codex-wake-{wake_id}"
+        with tempfile.NamedTemporaryFile("w", encoding="utf-8", delete=False) as handle:
+            handle.write(prompt)
+            prompt_path = handle.name
+        try:
+            subprocess.run(
+                ["tmux", "-S", socket, "load-buffer", "-b", buffer_name, prompt_path],
+                check=True,
+                text=True,
+                capture_output=True,
+            )
+            subprocess.run(
+                ["tmux", "-S", socket, "paste-buffer", "-d", "-b", buffer_name, "-t", pane],
+                check=True,
+                text=True,
+                capture_output=True,
+            )
+            subprocess.run(
+                ["tmux", "-S", socket, "send-keys", "-t", pane, "Enter"],
+                check=True,
+                text=True,
+                capture_output=True,
+            )
+        finally:
+            Path(prompt_path).unlink(missing_ok=True)
+
+
+def canonical_prompt(wake_id: str) -> str:
+    return f"WAKE_TRIGGER_ID={wake_id}\nResume the scheduled wake task.\n"
+
+
+def unsafe_pane_reason(text: str) -> str | None:
+    lowered = text.lower()
+    patterns = (
+        (r"\bapprove\b|\bapproval\b", "approval prompt visible"),
+        (r"\ballow\b.*\bcommand\b", "command approval prompt visible"),
+        (r"\bdeny\b.*\ballow\b", "confirmation prompt visible"),
+        (r"\brunning\b.*\bcommand\b|\btool\b.*\brunning\b", "tool appears to be running"),
+        (r"\bpress enter to continue\b|\bcontinue\?\b", "confirmation prompt visible"),
+    )
+    for pattern, reason in patterns:
+        if re.search(pattern, lowered, re.MULTILINE):
+            return reason
+    lines = [line.rstrip() for line in text.splitlines() if line.strip()]
+    if lines:
+        last = lines[-1]
+        if re.search(r"[$#%>]\s*$", last) and "codex" not in lowered:
+            return "pane appears to be a shell prompt"
+    return None
+
+
+def lock_name_for_pane(socket: str, pane: str) -> str:
+    safe = re.sub(r"[^A-Za-z0-9_.-]+", "_", f"{socket}_{pane}").strip("_")
+    return safe or "unknown-pane"
+
+
+class PaneLock:
+    def __init__(self, root: Path, socket: str, pane: str) -> None:
+        self.path = root / "locks" / f"{lock_name_for_pane(socket, pane)}.lock"
+        self.fd: int | None = None
+
+    def __enter__(self) -> "PaneLock":
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        try:
+            self.fd = os.open(str(self.path), os.O_CREAT | os.O_EXCL | os.O_WRONLY)
+        except FileExistsError as exc:
+            raise WakeError(f"pane lock already held: {self.path}") from exc
+        os.write(self.fd, str(os.getpid()).encode("ascii"))
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        if self.fd is not None:
+            os.close(self.fd)
+            self.fd = None
+        self.path.unlink(missing_ok=True)
+
+
+def ack_path(root: Path, wake_id: str) -> Path:
+    return root / "acks" / f"{wake_id}.submitted"
+
+
+def wait_for_ack(root: Path, wake_id: str, timeout_seconds: float) -> bool:
+    deadline = time.monotonic() + max(0.0, timeout_seconds)
+    path = ack_path(root, wake_id)
+    while True:
+        if path.exists():
+            return True
+        if time.monotonic() >= deadline:
+            return False
+        time.sleep(min(0.1, deadline - time.monotonic()))
+
+
+def target_from_record(record: dict) -> tuple[str, str]:
+    target = record.get("target")
+    if not isinstance(target, dict):
+        raise WakeError("record target must be an object")
+    if target.get("transport") != "tmux":
+        raise WakeError(f"unsupported target transport: {target.get('transport')}")
+    socket = target.get("tmux_socket")
+    pane = target.get("pane")
+    if not isinstance(socket, str) or not socket:
+        raise WakeError("tmux target requires tmux_socket")
+    if not isinstance(pane, str) or not pane:
+        raise WakeError("tmux target requires pane")
+    return socket, pane
+
+
+def backoff_for_attempt(attempt: int) -> int:
+    if attempt <= 1:
+        return DEFAULT_BACKOFF_SECONDS[0]
+    return DEFAULT_BACKOFF_SECONDS[min(attempt - 1, len(DEFAULT_BACKOFF_SECONDS) - 1)]
+
+
+def dispatch_firing_record(
+    root: Path,
+    found: WakePath,
+    *,
+    runner: TmuxRunner | None = None,
+    now: datetime | None = None,
+    ack_timeout_override: float | None = None,
+) -> DispatchResult:
+    current = now or utc_now()
+    record = dict(found.record)
+    if record.get("status") != "firing":
+        return DispatchResult("skipped", "record is not firing")
+    wake_id = record.get("id")
+    if not isinstance(wake_id, str) or not wake_id:
+        raise WakeError("wake record missing id")
+    try:
+        socket, pane = target_from_record(record)
+    except WakeError as exc:
+        record["last_error"] = str(exc)
+        record["status"] = "failed"
+        record = append_event(record, "failed", str(exc), current)
+        replace_record(root, found, record)
+        return DispatchResult("failed", str(exc))
+    tmux = runner or SubprocessTmuxRunner()
+
+    try:
+        with PaneLock(root, socket, pane):
+            attempt = int(record.get("attempts") or 0) + 1
+            record["attempts"] = attempt
+            record["updated_at"] = format_utc(current)
+            record = append_event(
+                record,
+                "dispatch_attempt",
+                f"Pasting canonical wake prompt into tmux pane {pane}",
+                current,
+                attempt=attempt,
+            )
+            replace_record(root, found, record)
+            captured = tmux.capture_pane(socket, pane)
+            unsafe = unsafe_pane_reason(captured)
+            if unsafe:
+                return requeue_or_fail(root, WakePath(root / "firing" / f"{wake_id}.json", record), record, f"unsafe pane: {unsafe}", current, "unsafe_pane")
+            tmux.paste_prompt(socket, pane, wake_id, canonical_prompt(wake_id))
+            timeout = ack_timeout_override
+            if timeout is None:
+                timeout = float(record.get("ack_timeout_seconds") or 30)
+            if wait_for_ack(root, wake_id, timeout):
+                record["status"] = "submitted"
+                record["updated_at"] = format_utc(current)
+                record = append_event(record, "ack_observed", "Wake prompt submission ack observed", current)
+                replace_record(root, WakePath(root / "firing" / f"{wake_id}.json", record), record)
+                return DispatchResult("submitted", "ack observed")
+            return requeue_or_fail(root, WakePath(root / "firing" / f"{wake_id}.json", record), record, "ack timeout", current, "ack_timeout")
+    except WakeError as exc:
+        return requeue_or_fail(root, found, record, str(exc), current, "failed")
+    except (OSError, subprocess.SubprocessError) as exc:
+        return requeue_or_fail(root, found, record, f"tmux dispatch failed: {exc}", current, "failed")
+
+
+def requeue_or_fail(
+    root: Path,
+    found: WakePath,
+    record: dict,
+    message: str,
+    now: datetime,
+    event_type: str,
+) -> DispatchResult:
+    attempts = int(record.get("attempts") or 0)
+    max_attempts = int(record.get("max_attempts") or 3)
+    record["updated_at"] = format_utc(now)
+    record["last_error"] = message
+    record = append_event(record, event_type, message, now, attempt=attempts)
+    if attempts >= max_attempts:
+        record["status"] = "failed"
+        record = append_event(record, "failed", "Maximum dispatch attempts reached", now, attempt=attempts)
+        replace_record(root, found, record)
+        return DispatchResult("failed", message)
+    delay = backoff_for_attempt(attempts + 1)
+    record["status"] = "pending"
+    record["next_attempt_at"] = format_utc(now + timedelta(seconds=delay))
+    record = append_event(record, "requeued", f"Wake requeued after {delay} seconds", now, attempt=attempts)
+    replace_record(root, found, record)
+    return DispatchResult("requeued", message)

--- a/src/codex_wake/records.py
+++ b/src/codex_wake/records.py
@@ -124,6 +124,22 @@ def make_event(event_type: str, message: str, now: datetime | None = None) -> di
     }
 
 
+def append_event(
+    record: dict[str, Any],
+    event_type: str,
+    message: str,
+    now: datetime | None = None,
+    **extra: Any,
+) -> dict[str, Any]:
+    updated = dict(record)
+    event = make_event(event_type, message, now)
+    event.update(extra)
+    events = list(updated.get("events") or [])
+    events.append(event)
+    updated["events"] = events
+    return updated
+
+
 def build_record(
     *,
     predicate: dict[str, Any],
@@ -233,9 +249,14 @@ def move_record(
     record["updated_at"] = format_utc(current)
     if last_error:
         record["last_error"] = last_error
-    events = list(record.get("events") or [])
-    events.append(make_event(event_type, message, current))
-    record["events"] = events
+    record = append_event(record, event_type, message, current)
+    destination = write_record(root, record)
+    if found.path != destination and found.path.exists():
+        found.path.unlink()
+    return destination
+
+
+def replace_record(root: Path, found: WakePath, record: dict[str, Any]) -> Path:
     destination = write_record(root, record)
     if found.path != destination and found.path.exists():
         found.path.unlink()

--- a/src/codex_wake/records.py
+++ b/src/codex_wake/records.py
@@ -72,6 +72,11 @@ def parse_timestamp(value: str) -> datetime:
     return parsed.astimezone(UTC).replace(microsecond=0)
 
 
+def parse_utc_timestamp(value: str) -> datetime:
+    parsed = parse_timestamp(value)
+    return parsed.astimezone(UTC).replace(microsecond=0)
+
+
 def make_wake_id(now: datetime | None = None) -> str:
     current = now or utc_now()
     stamp = current.astimezone(UTC).strftime("%Y%m%d_%H%M%S")
@@ -203,6 +208,33 @@ def cancel_record(root: Path, wake_id: str, now: datetime | None = None) -> Path
     record["updated_at"] = format_utc(current)
     events = list(record.get("events") or [])
     events.append(make_event("cancelled", "Wake cancelled by operator", current))
+    record["events"] = events
+    destination = write_record(root, record)
+    if found.path != destination and found.path.exists():
+        found.path.unlink()
+    return destination
+
+
+def move_record(
+    root: Path,
+    found: WakePath,
+    status: str,
+    *,
+    event_type: str,
+    message: str,
+    now: datetime | None = None,
+    last_error: str | None = None,
+) -> Path:
+    if status not in VALID_STATUSES:
+        raise WakeError(f"invalid wake status: {status}")
+    current = now or utc_now()
+    record = dict(found.record)
+    record["status"] = status
+    record["updated_at"] = format_utc(current)
+    if last_error:
+        record["last_error"] = last_error
+    events = list(record.get("events") or [])
+    events.append(make_event(event_type, message, current))
     record["events"] = events
     destination = write_record(root, record)
     if found.path != destination and found.path.exists():

--- a/src/codex_wake/records.py
+++ b/src/codex_wake/records.py
@@ -12,6 +12,7 @@ from typing import Any
 
 SCHEMA_VERSION = 1
 ACTIVE_STATUS_DIRS = ("pending", "firing", "submitted", "failed", "cancelled", "expired")
+TERMINAL_STATUSES = {"submitted", "failed", "cancelled", "expired"}
 VALID_STATUSES = set(ACTIVE_STATUS_DIRS) | {"archived"}
 
 
@@ -206,11 +207,32 @@ def iter_records(root: Path) -> list[WakePath]:
     return sorted(results, key=lambda item: (item.record.get("created_at", ""), item.record.get("id", "")))
 
 
+def iter_archived_records(root: Path) -> list[WakePath]:
+    archive_dir = root / "archive"
+    results: list[WakePath] = []
+    if not archive_dir.exists():
+        return results
+    for path in sorted(archive_dir.glob("*.json")):
+        try:
+            record = json.loads(path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError:
+            continue
+        results.append(WakePath(path=path, record=record))
+    return sorted(results, key=lambda item: (item.record.get("archived_at", ""), item.record.get("id", "")))
+
+
 def find_record(root: Path, wake_id: str) -> WakePath:
     for item in iter_records(root):
         if item.record.get("id") == wake_id:
             return item
     raise WakeError(f"wake not found: {wake_id}")
+
+
+def all_records(root: Path, include_archive: bool = False) -> list[WakePath]:
+    records = iter_records(root)
+    if include_archive:
+        records.extend(iter_archived_records(root))
+    return sorted(records, key=lambda item: (item.record.get("created_at", ""), item.record.get("id", "")))
 
 
 def cancel_record(root: Path, wake_id: str, now: datetime | None = None) -> Path:
@@ -261,3 +283,35 @@ def replace_record(root: Path, found: WakePath, record: dict[str, Any]) -> Path:
     if found.path != destination and found.path.exists():
         found.path.unlink()
     return destination
+
+
+def archive_record(root: Path, wake_id: str, now: datetime | None = None) -> Path:
+    found = find_record(root, wake_id)
+    record = dict(found.record)
+    status = record.get("status")
+    if status not in TERMINAL_STATUSES:
+        raise WakeError(f"cannot archive wake in status {status}")
+    current = now or utc_now()
+    record["previous_status"] = status
+    record["status"] = "archived"
+    record["archived_at"] = format_utc(current)
+    record["updated_at"] = format_utc(current)
+    record = append_event(record, "archived", "Wake archived by operator", current)
+    archive_dir = root / "archive"
+    archive_dir.mkdir(parents=True, exist_ok=True)
+    final_path = archive_dir / f"{wake_id}.json"
+    temp_path = final_path.with_suffix(".json.tmp")
+    temp_path.write_text(json.dumps(record, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    temp_path.replace(final_path)
+    if found.path.exists():
+        found.path.unlink()
+    return final_path
+
+
+def archive_terminal_records(root: Path, now: datetime | None = None) -> list[Path]:
+    archived: list[Path] = []
+    for item in list(iter_records(root)):
+        wake_id = item.record.get("id")
+        if item.record.get("status") in TERMINAL_STATUSES and isinstance(wake_id, str):
+            archived.append(archive_record(root, wake_id, now=now))
+    return archived

--- a/src/codex_wake/records.py
+++ b/src/codex_wake/records.py
@@ -1,0 +1,210 @@
+from __future__ import annotations
+
+import json
+import os
+import re
+import secrets
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Any
+
+
+SCHEMA_VERSION = 1
+ACTIVE_STATUS_DIRS = ("pending", "firing", "submitted", "failed", "cancelled", "expired")
+VALID_STATUSES = set(ACTIVE_STATUS_DIRS) | {"archived"}
+
+
+class WakeError(ValueError):
+    """Raised for invalid wake input."""
+
+
+@dataclass(frozen=True)
+class WakePath:
+    path: Path
+    record: dict[str, Any]
+
+
+def utc_now() -> datetime:
+    return datetime.now(UTC).replace(microsecond=0)
+
+
+def format_utc(value: datetime) -> str:
+    return value.astimezone(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def parse_duration(value: str) -> timedelta:
+    text = value.strip().lower()
+    if not text:
+        raise WakeError("duration is required")
+    pattern = re.compile(r"(\d+)([smhd])")
+    pos = 0
+    total = timedelta()
+    for match in pattern.finditer(text):
+        if match.start() != pos:
+            raise WakeError(f"invalid duration: {value}")
+        amount = int(match.group(1))
+        unit = match.group(2)
+        if unit == "s":
+            total += timedelta(seconds=amount)
+        elif unit == "m":
+            total += timedelta(minutes=amount)
+        elif unit == "h":
+            total += timedelta(hours=amount)
+        elif unit == "d":
+            total += timedelta(days=amount)
+        pos = match.end()
+    if pos != len(text) or total <= timedelta():
+        raise WakeError(f"invalid duration: {value}")
+    return total
+
+
+def parse_timestamp(value: str) -> datetime:
+    text = value.strip()
+    if text.endswith("Z"):
+        text = f"{text[:-1]}+00:00"
+    try:
+        parsed = datetime.fromisoformat(text)
+    except ValueError as exc:
+        raise WakeError(f"invalid timestamp: {value}") from exc
+    if parsed.tzinfo is None:
+        raise WakeError("timestamp must include a timezone offset or Z")
+    return parsed.astimezone(UTC).replace(microsecond=0)
+
+
+def make_wake_id(now: datetime | None = None) -> str:
+    current = now or utc_now()
+    stamp = current.astimezone(UTC).strftime("%Y%m%d_%H%M%S")
+    return f"wake_{stamp}_{secrets.token_hex(2)}"
+
+
+def default_wake_root(cwd: Path | None = None) -> Path:
+    base = cwd or Path.cwd()
+    return base / ".codex" / "wake"
+
+
+def normalize_prompt(parts: list[str]) -> str:
+    cleaned = list(parts)
+    if cleaned and cleaned[0] == "--":
+        cleaned = cleaned[1:]
+    prompt = " ".join(cleaned).strip()
+    if not prompt:
+        raise WakeError("prompt is required after --")
+    return prompt
+
+
+def capture_tmux_target(env: dict[str, str] | None = None) -> dict[str, str]:
+    source = env if env is not None else os.environ
+    pane = source.get("TMUX_PANE")
+    tmux_env = source.get("TMUX")
+    if not pane:
+        raise WakeError("TMUX_PANE is required to create a tmux-targeted wake")
+    if not tmux_env:
+        raise WakeError("TMUX is required to resolve the tmux socket")
+    socket = tmux_env.split(",", 1)[0]
+    if not socket:
+        raise WakeError("TMUX did not contain a socket path")
+    return {
+        "transport": "tmux",
+        "tmux_socket": socket,
+        "pane": pane,
+    }
+
+
+def make_event(event_type: str, message: str, now: datetime | None = None) -> dict[str, Any]:
+    return {
+        "at": format_utc(now or utc_now()),
+        "type": event_type,
+        "message": message,
+    }
+
+
+def build_record(
+    *,
+    predicate: dict[str, Any],
+    prompt: str,
+    cwd: Path,
+    target: dict[str, str],
+    now: datetime | None = None,
+) -> dict[str, Any]:
+    current = now or utc_now()
+    wake_id = make_wake_id(current)
+    timestamp = format_utc(current)
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "id": wake_id,
+        "created_at": timestamp,
+        "updated_at": timestamp,
+        "cwd": str(cwd.resolve()),
+        "target": target,
+        "predicate": predicate,
+        "prompt": prompt,
+        "status": "pending",
+        "attempts": 0,
+        "max_attempts": 3,
+        "ack_timeout_seconds": 30,
+        "next_attempt_at": predicate.get("due_at", timestamp),
+        "events": [make_event("created", "Wake record created", current)],
+    }
+
+
+def ensure_runtime_dirs(root: Path) -> None:
+    for name in ACTIVE_STATUS_DIRS + ("acks", "logs", "locks", "archive"):
+        (root / name).mkdir(parents=True, exist_ok=True)
+
+
+def write_record(root: Path, record: dict[str, Any]) -> Path:
+    ensure_runtime_dirs(root)
+    status = record.get("status")
+    wake_id = record.get("id")
+    if status not in VALID_STATUSES:
+        raise WakeError(f"invalid wake status: {status}")
+    if not isinstance(wake_id, str) or not wake_id:
+        raise WakeError("wake record missing id")
+    target_dir = root / status
+    target_dir.mkdir(parents=True, exist_ok=True)
+    final_path = target_dir / f"{wake_id}.json"
+    temp_path = final_path.with_suffix(".json.tmp")
+    temp_path.write_text(json.dumps(record, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    temp_path.replace(final_path)
+    return final_path
+
+
+def iter_records(root: Path) -> list[WakePath]:
+    results: list[WakePath] = []
+    for status in ACTIVE_STATUS_DIRS:
+        directory = root / status
+        if not directory.exists():
+            continue
+        for path in sorted(directory.glob("*.json")):
+            try:
+                record = json.loads(path.read_text(encoding="utf-8"))
+            except json.JSONDecodeError:
+                continue
+            results.append(WakePath(path=path, record=record))
+    return sorted(results, key=lambda item: (item.record.get("created_at", ""), item.record.get("id", "")))
+
+
+def find_record(root: Path, wake_id: str) -> WakePath:
+    for item in iter_records(root):
+        if item.record.get("id") == wake_id:
+            return item
+    raise WakeError(f"wake not found: {wake_id}")
+
+
+def cancel_record(root: Path, wake_id: str, now: datetime | None = None) -> Path:
+    found = find_record(root, wake_id)
+    record = dict(found.record)
+    status = record.get("status")
+    if status in {"submitted", "failed", "cancelled", "expired", "archived"}:
+        raise WakeError(f"cannot cancel wake in status {status}")
+    current = now or utc_now()
+    record["status"] = "cancelled"
+    record["updated_at"] = format_utc(current)
+    events = list(record.get("events") or [])
+    events.append(make_event("cancelled", "Wake cancelled by operator", current))
+    record["events"] = events
+    destination = write_record(root, record)
+    if found.path != destination and found.path.exists():
+        found.path.unlink()
+    return destination

--- a/tests/test_app_server.py
+++ b/tests/test_app_server.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from datetime import UTC, datetime
+from pathlib import Path
+
+from codex_wake.app_server import dispatch_app_server_record
+from codex_wake.injector import canonical_prompt, dispatch_firing_record
+from codex_wake.records import WakePath, build_record, write_record
+
+
+class FakeAppServerClient:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, object]] = []
+
+    def initialize(self) -> dict:
+        self.calls.append(("initialize", None))
+        return {"userAgent": "fake", "codexHome": "/tmp/codex", "platformFamily": "unix", "platformOs": "linux"}
+
+    def resume_thread(self, thread_id: str, cwd: str | None = None) -> dict:
+        self.calls.append(("thread/resume", {"thread_id": thread_id, "cwd": cwd}))
+        return {"thread": {"id": thread_id}}
+
+    def start_turn(self, thread_id: str, prompt: str, cwd: str | None = None) -> dict:
+        self.calls.append(("turn/start", {"thread_id": thread_id, "prompt": prompt, "cwd": cwd}))
+        return {"turn": {"id": "turn_123"}}
+
+    def close(self) -> None:
+        self.calls.append(("close", None))
+
+
+class AppServerTests(unittest.TestCase):
+    def make_record(self, root: Path, cwd: Path) -> WakePath:
+        record = build_record(
+            predicate={"type": "not_before", "due_at": "2026-05-18T21:15:00Z"},
+            prompt="full prompt must not be sent",
+            cwd=cwd,
+            target={"transport": "app-server", "endpoint": "stdio://", "thread_id": "thread_abc"},
+            now=datetime(2026, 5, 18, 20, 30, tzinfo=UTC),
+        )
+        record["id"] = "wake_app"
+        record["status"] = "firing"
+        path = write_record(root, record)
+        return WakePath(path=path, record=record)
+
+    def test_dispatch_app_server_record_starts_turn_with_canonical_prompt(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / "wake"
+            found = self.make_record(root, Path(tmp))
+            client = FakeAppServerClient()
+
+            result = dispatch_app_server_record(root, found, client=client, now=datetime(2026, 5, 18, 21, 0, tzinfo=UTC))
+
+            self.assertEqual(result.status, "submitted")
+            self.assertEqual([call[0] for call in client.calls], ["initialize", "thread/resume", "turn/start"])
+            turn_call = client.calls[-1][1]
+            self.assertEqual(turn_call["prompt"], canonical_prompt("wake_app"))
+            self.assertNotIn("full prompt", turn_call["prompt"])
+            data = json.loads((root / "submitted" / "wake_app.json").read_text())
+            self.assertEqual(data["status"], "submitted")
+            self.assertEqual(data["events"][-1]["type"], "ack_observed")
+
+    def test_unsupported_endpoint_fails_record(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / "wake"
+            found = self.make_record(root, Path(tmp))
+            found.record["target"]["endpoint"] = "ws://127.0.0.1:4500"
+            write_record(root, found.record)
+
+            result = dispatch_app_server_record(root, found, client=FakeAppServerClient())
+
+            self.assertEqual(result.status, "failed")
+            data = json.loads((root / "failed" / "wake_app.json").read_text())
+            self.assertIn("only app-server stdio:// transport is implemented", data["last_error"])
+
+    def test_generic_dispatcher_routes_app_server_target(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / "wake"
+            found = self.make_record(root, Path(tmp))
+            # Exercise only target routing and validation failure path; full app-server dispatch is
+            # covered above with an injected client.
+            found.record["target"]["endpoint"] = "ws://127.0.0.1:4500"
+            write_record(root, found.record)
+
+            result = dispatch_firing_record(root, found)
+
+            self.assertEqual(result.status, "failed")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -62,6 +62,15 @@ class CliTests(unittest.TestCase):
             self.assertTrue((root / "cancelled" / f"{wake_id}.json").exists())
             self.assertFalse((root / "pending" / f"{wake_id}.json").exists())
 
+            code, archive_out, err = self.run_cli(["archive", wake_id], root)
+            self.assertEqual(code, 0, err)
+            self.assertIn("archived", archive_out)
+            self.assertTrue((root / "archive" / f"{wake_id}.json").exists())
+
+            code, archived_list, err = self.run_cli(["list", "--archived"], root)
+            self.assertEqual(code, 0, err)
+            self.assertIn(wake_id, archived_list)
+
     def test_create_requires_tmux_environment(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -82,6 +82,53 @@ class CliTests(unittest.TestCase):
             self.assertEqual(code, 2)
             self.assertIn("TMUX_PANE is required", stderr.getvalue())
 
+    def test_app_server_thread_target_does_not_require_tmux(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            stdout = io.StringIO()
+            stderr = io.StringIO()
+            with patch.dict(os.environ, {"TMUX_PANE": "", "TMUX": ""}, clear=False):
+                with contextlib.redirect_stdout(stdout), contextlib.redirect_stderr(stderr):
+                    code = cli.main(
+                        [
+                            "--wake-root",
+                            str(root),
+                            "after",
+                            "--app-server-thread-id",
+                            "thread_abc",
+                            "1m",
+                            "--",
+                            "Wake app server",
+                        ]
+                    )
+            self.assertEqual(code, 0, stderr.getvalue())
+            wake_id = stdout.getvalue().split()[0]
+            data = json.loads((root / "pending" / f"{wake_id}.json").read_text())
+            self.assertEqual(data["target"], {"transport": "app-server", "endpoint": "stdio://", "thread_id": "thread_abc"})
+
+    def test_app_server_rejects_non_stdio_endpoint(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            stdout = io.StringIO()
+            stderr = io.StringIO()
+            with contextlib.redirect_stdout(stdout), contextlib.redirect_stderr(stderr):
+                code = cli.main(
+                    [
+                        "--wake-root",
+                        str(root),
+                        "after",
+                        "--app-server-thread-id",
+                        "thread_abc",
+                        "--app-server-endpoint",
+                        "ws://127.0.0.1:4500",
+                        "1m",
+                        "--",
+                        "Wake app server",
+                    ]
+                )
+            self.assertEqual(code, 2)
+            self.assertIn("only app-server endpoint stdio://", stderr.getvalue())
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import contextlib
+import io
+import json
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from codex_wake import cli
+
+
+class CliTests(unittest.TestCase):
+    def run_cli(self, argv: list[str], root: Path) -> tuple[int, str, str]:
+        env = {
+            **os.environ,
+            "TMUX_PANE": "%11",
+            "TMUX": "/tmp/tmux-1000/default,123,0",
+        }
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+        with patch.dict(os.environ, env, clear=False):
+            with contextlib.redirect_stdout(stdout), contextlib.redirect_stderr(stderr):
+                code = cli.main(["--wake-root", str(root), *argv])
+        return code, stdout.getvalue(), stderr.getvalue()
+
+    def test_after_creates_pending_wake(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            code, out, err = self.run_cli(["after", "45m", "--", "Continue later"], root)
+            self.assertEqual(code, 0, err)
+            wake_id = out.split()[0]
+            record_path = root / "pending" / f"{wake_id}.json"
+            data = json.loads(record_path.read_text())
+            self.assertEqual(data["predicate"]["type"], "not_before")
+            self.assertEqual(data["target"]["pane"], "%11")
+            self.assertEqual(data["prompt"], "Continue later")
+            self.assertEqual(data["status"], "pending")
+
+    def test_file_show_list_and_cancel(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            code, out, err = self.run_cli(["file", ".codex/events/pytest.done", "--", "Read log"], root)
+            self.assertEqual(code, 0, err)
+            wake_id = out.split()[0]
+
+            code, show_out, err = self.run_cli(["show", wake_id], root)
+            self.assertEqual(code, 0, err)
+            shown = json.loads(show_out)
+            self.assertEqual(shown["predicate"], {"type": "file_exists", "path": ".codex/events/pytest.done"})
+
+            code, list_out, err = self.run_cli(["list"], root)
+            self.assertEqual(code, 0, err)
+            self.assertIn(wake_id, list_out)
+            self.assertIn("file_exists", list_out)
+
+            code, cancel_out, err = self.run_cli(["cancel", wake_id], root)
+            self.assertEqual(code, 0, err)
+            self.assertIn("cancelled", cancel_out)
+            self.assertTrue((root / "cancelled" / f"{wake_id}.json").exists())
+            self.assertFalse((root / "pending" / f"{wake_id}.json").exists())
+
+    def test_create_requires_tmux_environment(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            stdout = io.StringIO()
+            stderr = io.StringIO()
+            with patch.dict(os.environ, {"TMUX_PANE": "", "TMUX": ""}, clear=False):
+                with contextlib.redirect_stdout(stdout), contextlib.redirect_stderr(stderr):
+                    code = cli.main(["--wake-root", str(root), "after", "1m", "--", "Wake"])
+            self.assertEqual(code, 2)
+            self.assertIn("TMUX_PANE is required", stderr.getvalue())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from datetime import UTC, datetime
+from pathlib import Path
+
+from codex_wake.daemon import poll_once
+from codex_wake.records import build_record, write_record
+
+
+class DaemonTests(unittest.TestCase):
+    def make_record(self, tmp: str, predicate: dict) -> dict:
+        now = datetime(2026, 5, 18, 20, 30, tzinfo=UTC)
+        record = build_record(
+            predicate=predicate,
+            prompt="continue",
+            cwd=Path(tmp),
+            target={"transport": "tmux", "tmux_socket": "/tmp/tmux/default", "pane": "%1"},
+            now=now,
+        )
+        record["id"] = f"wake_{len(predicate)}"
+        return record
+
+    def test_not_before_moves_ready_record_to_firing(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / "wake"
+            record = self.make_record(tmp, {"type": "not_before", "due_at": "2026-05-18T21:15:00Z"})
+            write_record(root, record)
+
+            result = poll_once(root, now=datetime(2026, 5, 18, 21, 15, tzinfo=UTC))
+
+            self.assertEqual(result.fired, 1)
+            self.assertFalse((root / "pending" / f"{record['id']}.json").exists())
+            firing = root / "firing" / f"{record['id']}.json"
+            self.assertTrue(firing.exists())
+            data = json.loads(firing.read_text())
+            self.assertEqual(data["status"], "firing")
+            self.assertEqual(data["events"][-1]["type"], "predicate_matched")
+
+    def test_not_before_leaves_future_record_pending(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / "wake"
+            record = self.make_record(tmp, {"type": "not_before", "due_at": "2026-05-18T21:15:00Z"})
+            write_record(root, record)
+
+            result = poll_once(root, now=datetime(2026, 5, 18, 21, 14, tzinfo=UTC))
+
+            self.assertEqual(result.pending, 1)
+            self.assertTrue((root / "pending" / f"{record['id']}.json").exists())
+
+    def test_file_exists_relative_to_record_cwd(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / "wake"
+            event_path = Path(tmp) / ".codex" / "events" / "pytest.done"
+            event_path.parent.mkdir(parents=True)
+            event_path.write_text("", encoding="utf-8")
+            record = self.make_record(tmp, {"type": "file_exists", "path": ".codex/events/pytest.done"})
+            record["id"] = "wake_file"
+            write_record(root, record)
+
+            result = poll_once(root, now=datetime(2026, 5, 18, 21, 15, tzinfo=UTC))
+
+            self.assertEqual(result.fired, 1)
+            self.assertTrue((root / "firing" / "wake_file.json").exists())
+
+    def test_invalid_predicate_moves_to_failed(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / "wake"
+            record = self.make_record(tmp, {"type": "command", "cmd": "pytest"})
+            record["id"] = "wake_bad"
+            write_record(root, record)
+
+            result = poll_once(root, now=datetime(2026, 5, 18, 21, 15, tzinfo=UTC))
+
+            self.assertEqual(result.failed, 1)
+            failed = root / "failed" / "wake_bad.json"
+            self.assertTrue(failed.exists())
+            data = json.loads(failed.read_text())
+            self.assertEqual(data["status"], "failed")
+            self.assertIn("unsupported predicate type", data["last_error"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -29,7 +29,7 @@ class DaemonTests(unittest.TestCase):
             record = self.make_record(tmp, {"type": "not_before", "due_at": "2026-05-18T21:15:00Z"})
             write_record(root, record)
 
-            result = poll_once(root, now=datetime(2026, 5, 18, 21, 15, tzinfo=UTC))
+            result = poll_once(root, now=datetime(2026, 5, 18, 21, 15, tzinfo=UTC), dispatch=False)
 
             self.assertEqual(result.fired, 1)
             self.assertFalse((root / "pending" / f"{record['id']}.json").exists())
@@ -45,7 +45,7 @@ class DaemonTests(unittest.TestCase):
             record = self.make_record(tmp, {"type": "not_before", "due_at": "2026-05-18T21:15:00Z"})
             write_record(root, record)
 
-            result = poll_once(root, now=datetime(2026, 5, 18, 21, 14, tzinfo=UTC))
+            result = poll_once(root, now=datetime(2026, 5, 18, 21, 14, tzinfo=UTC), dispatch=False)
 
             self.assertEqual(result.pending, 1)
             self.assertTrue((root / "pending" / f"{record['id']}.json").exists())
@@ -60,7 +60,7 @@ class DaemonTests(unittest.TestCase):
             record["id"] = "wake_file"
             write_record(root, record)
 
-            result = poll_once(root, now=datetime(2026, 5, 18, 21, 15, tzinfo=UTC))
+            result = poll_once(root, now=datetime(2026, 5, 18, 21, 15, tzinfo=UTC), dispatch=False)
 
             self.assertEqual(result.fired, 1)
             self.assertTrue((root / "firing" / "wake_file.json").exists())
@@ -72,7 +72,7 @@ class DaemonTests(unittest.TestCase):
             record["id"] = "wake_bad"
             write_record(root, record)
 
-            result = poll_once(root, now=datetime(2026, 5, 18, 21, 15, tzinfo=UTC))
+            result = poll_once(root, now=datetime(2026, 5, 18, 21, 15, tzinfo=UTC), dispatch=False)
 
             self.assertEqual(result.failed, 1)
             failed = root / "failed" / "wake_bad.json"

--- a/tests/test_hook.py
+++ b/tests/test_hook.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import contextlib
+import io
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from codex_wake.hook import extract_wake_id, handle_payload, main
+from codex_wake.records import build_record, write_record
+
+
+class HookTests(unittest.TestCase):
+    def make_payload(self, cwd: Path, prompt: str) -> dict:
+        return {
+            "prompt": prompt,
+            "cwd": str(cwd),
+            "turn_id": "turn_123",
+            "session_id": "session_456",
+            "hook_event_name": "UserPromptSubmit",
+        }
+
+    def test_extract_wake_id(self) -> None:
+        self.assertEqual(extract_wake_id("WAKE_TRIGGER_ID=wake_123\nResume"), "wake_123")
+        self.assertIsNone(extract_wake_id("ordinary prompt"))
+
+    def test_no_match_returns_none_and_writes_no_ack(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            output = handle_payload(self.make_payload(Path(tmp), "ordinary prompt"))
+            self.assertIsNone(output)
+            self.assertFalse((Path(tmp) / ".codex" / "wake" / "acks").exists())
+
+    def test_found_record_writes_ack_and_adds_context(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            cwd = Path(tmp)
+            wake_root = cwd / ".codex" / "wake"
+            record = build_record(
+                predicate={"type": "file_exists", "path": ".codex/events/pytest.done"},
+                prompt="Read pytest log and continue",
+                cwd=cwd,
+                target={"transport": "tmux", "tmux_socket": "/tmp/tmux/default", "pane": "%1"},
+            )
+            record["id"] = "wake_test"
+            record["status"] = "firing"
+            record["context_paths"] = ["docs/dev/context.md"]
+            record["evidence_paths"] = [".codex/events/pytest.log"]
+            write_record(wake_root, record)
+
+            output = handle_payload(self.make_payload(cwd, "WAKE_TRIGGER_ID=wake_test\nResume"))
+
+            ack_path = wake_root / "acks" / "wake_test.submitted"
+            self.assertTrue(ack_path.exists())
+            ack = json.loads(ack_path.read_text())
+            self.assertEqual(ack["wake_id"], "wake_test")
+            self.assertEqual(ack["turn_id"], "turn_123")
+            context = output["hookSpecificOutput"]["additionalContext"]
+            self.assertIn("A scheduled wake trigger fired.", context)
+            self.assertIn("Read pytest log and continue", context)
+            self.assertIn(".codex/events/pytest.log", context)
+
+    def test_missing_record_writes_ack_and_warns(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            cwd = Path(tmp)
+            output = handle_payload(self.make_payload(cwd, "WAKE_TRIGGER_ID=wake_missing\nResume"))
+
+            self.assertTrue((cwd / ".codex" / "wake" / "acks" / "wake_missing.submitted").exists())
+            context = output["hookSpecificOutput"]["additionalContext"]
+            self.assertIn("trigger file was not found", context)
+
+    def test_main_prints_hook_output(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            payload = self.make_payload(Path(tmp), "WAKE_TRIGGER_ID=wake_missing\nResume")
+            stdin = io.StringIO(json.dumps(payload))
+            stdout = io.StringIO()
+            with patch("sys.stdin", stdin), contextlib.redirect_stdout(stdout):
+                code = main([])
+            self.assertEqual(code, 0)
+            parsed = json.loads(stdout.getvalue())
+            self.assertEqual(parsed["hookSpecificOutput"]["hookEventName"], "UserPromptSubmit")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_injector.py
+++ b/tests/test_injector.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from datetime import UTC, datetime
+from pathlib import Path
+
+from codex_wake.injector import (
+    PaneLock,
+    canonical_prompt,
+    dispatch_firing_record,
+    lock_name_for_pane,
+    unsafe_pane_reason,
+)
+from codex_wake.records import WakePath, build_record, write_record
+
+
+class FakeTmuxRunner:
+    def __init__(self, capture: str = "Codex ready") -> None:
+        self.capture = capture
+        self.pastes: list[tuple[str, str, str, str]] = []
+
+    def capture_pane(self, socket: str, pane: str) -> str:
+        return self.capture
+
+    def paste_prompt(self, socket: str, pane: str, wake_id: str, prompt: str) -> None:
+        self.pastes.append((socket, pane, wake_id, prompt))
+
+
+class InjectorTests(unittest.TestCase):
+    def make_firing_record(self, root: Path, cwd: Path, prompt: str = "full continuation prompt") -> WakePath:
+        now = datetime(2026, 5, 18, 20, 30, tzinfo=UTC)
+        record = build_record(
+            predicate={"type": "not_before", "due_at": "2026-05-18T21:15:00Z"},
+            prompt=prompt,
+            cwd=cwd,
+            target={"transport": "tmux", "tmux_socket": "/tmp/tmux/default", "pane": "%1"},
+            now=now,
+        )
+        record["id"] = "wake_test"
+        record["status"] = "firing"
+        path = write_record(root, record)
+        return WakePath(path=path, record=record)
+
+    def test_canonical_prompt_uses_wake_id_only(self) -> None:
+        self.assertEqual(canonical_prompt("wake_123"), "WAKE_TRIGGER_ID=wake_123\nResume the scheduled wake task.\n")
+
+    def test_unsafe_pane_reason_rejects_shell_prompt_and_approval(self) -> None:
+        self.assertEqual(unsafe_pane_reason("Approve command?"), "approval prompt visible")
+        self.assertEqual(unsafe_pane_reason("user@host:~/repo$ "), "pane appears to be a shell prompt")
+        self.assertIsNone(unsafe_pane_reason("Codex\nready for input"))
+
+    def test_pane_lock_rejects_concurrent_lock(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            with PaneLock(root, "/tmp/tmux/default", "%1"):
+                with self.assertRaises(ValueError):
+                    with PaneLock(root, "/tmp/tmux/default", "%1"):
+                        pass
+            self.assertFalse((root / "locks" / f"{lock_name_for_pane('/tmp/tmux/default', '%1')}.lock").exists())
+
+    def test_dispatch_pastes_only_canonical_prompt_and_requeues_without_ack(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / "wake"
+            found = self.make_firing_record(root, Path(tmp), prompt="SECRET FULL PROMPT")
+            runner = FakeTmuxRunner()
+
+            result = dispatch_firing_record(
+                root,
+                found,
+                runner=runner,
+                now=datetime(2026, 5, 18, 21, 15, tzinfo=UTC),
+                ack_timeout_override=0,
+            )
+
+            self.assertEqual(result.status, "requeued")
+            self.assertEqual(len(runner.pastes), 1)
+            self.assertEqual(runner.pastes[0][3], canonical_prompt("wake_test"))
+            self.assertNotIn("SECRET FULL PROMPT", runner.pastes[0][3])
+            pending = root / "pending" / "wake_test.json"
+            self.assertTrue(pending.exists())
+            data = json.loads(pending.read_text())
+            self.assertEqual(data["attempts"], 1)
+            self.assertEqual(data["events"][-2]["type"], "ack_timeout")
+            self.assertEqual(data["events"][-1]["type"], "requeued")
+
+    def test_dispatch_marks_submitted_when_ack_exists(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / "wake"
+            found = self.make_firing_record(root, Path(tmp))
+            ack_dir = root / "acks"
+            ack_dir.mkdir(parents=True, exist_ok=True)
+            (ack_dir / "wake_test.submitted").write_text("{}", encoding="utf-8")
+
+            result = dispatch_firing_record(
+                root,
+                found,
+                runner=FakeTmuxRunner(),
+                now=datetime(2026, 5, 18, 21, 15, tzinfo=UTC),
+                ack_timeout_override=0,
+            )
+
+            self.assertEqual(result.status, "submitted")
+            self.assertTrue((root / "submitted" / "wake_test.json").exists())
+
+    def test_unsafe_pane_requeues_and_does_not_paste(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / "wake"
+            found = self.make_firing_record(root, Path(tmp))
+            runner = FakeTmuxRunner(capture="Approve command?")
+
+            result = dispatch_firing_record(
+                root,
+                found,
+                runner=runner,
+                now=datetime(2026, 5, 18, 21, 15, tzinfo=UTC),
+                ack_timeout_override=0,
+            )
+
+            self.assertEqual(result.status, "requeued")
+            self.assertEqual(runner.pastes, [])
+            data = json.loads((root / "pending" / "wake_test.json").read_text())
+            self.assertEqual(data["attempts"], 1)
+            self.assertEqual(data["events"][-2]["type"], "unsafe_pane")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_records.py
+++ b/tests/test_records.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+import unittest
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from unittest.mock import patch
+
+from codex_wake.records import (
+    build_record,
+    cancel_record,
+    capture_tmux_target,
+    format_utc,
+    parse_duration,
+    parse_timestamp,
+    write_record,
+)
+
+
+class RecordTests(unittest.TestCase):
+    def test_parse_duration_supports_compound_values(self) -> None:
+        self.assertEqual(parse_duration("1h30m"), timedelta(minutes=90))
+        self.assertEqual(parse_duration("2d3h4m5s"), timedelta(days=2, hours=3, minutes=4, seconds=5))
+
+    def test_parse_duration_rejects_invalid_values(self) -> None:
+        with self.assertRaises(ValueError):
+            parse_duration("45")
+        with self.assertRaises(ValueError):
+            parse_duration("m45")
+
+    def test_parse_timestamp_requires_timezone_and_normalizes_utc(self) -> None:
+        self.assertEqual(format_utc(parse_timestamp("2026-05-18T17:30:00-05:00")), "2026-05-18T22:30:00Z")
+        self.assertEqual(format_utc(parse_timestamp("2026-05-18T22:30:00Z")), "2026-05-18T22:30:00Z")
+        with self.assertRaises(ValueError):
+            parse_timestamp("2026-05-18T17:30:00")
+
+    def test_capture_tmux_target_from_environment(self) -> None:
+        target = capture_tmux_target({"TMUX_PANE": "%11", "TMUX": "/tmp/tmux-1000/default,123,0"})
+        self.assertEqual(target["transport"], "tmux")
+        self.assertEqual(target["pane"], "%11")
+        self.assertEqual(target["tmux_socket"], "/tmp/tmux-1000/default")
+
+    def test_write_and_cancel_record(self) -> None:
+        now = datetime(2026, 5, 18, 20, 30, tzinfo=UTC)
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            record = build_record(
+                predicate={"type": "not_before", "due_at": "2026-05-18T21:15:00Z"},
+                prompt="continue",
+                cwd=Path(tmp),
+                target={"transport": "tmux", "tmux_socket": "/tmp/tmux/default", "pane": "%1"},
+                now=now,
+            )
+            with patch("codex_wake.records.secrets.token_hex", return_value="9f3a"):
+                record["id"] = "wake_20260518_203000_9f3a"
+            path = write_record(root, record)
+            self.assertTrue(path.exists())
+            cancelled = cancel_record(root, record["id"], now=now)
+            data = json.loads(cancelled.read_text())
+            self.assertEqual(data["status"], "cancelled")
+            self.assertFalse(path.exists())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_records.py
+++ b/tests/test_records.py
@@ -9,6 +9,8 @@ from pathlib import Path
 from unittest.mock import patch
 
 from codex_wake.records import (
+    archive_record,
+    archive_terminal_records,
     build_record,
     cancel_record,
     capture_tmux_target,
@@ -61,6 +63,56 @@ class RecordTests(unittest.TestCase):
             data = json.loads(cancelled.read_text())
             self.assertEqual(data["status"], "cancelled")
             self.assertFalse(path.exists())
+
+    def test_archive_record_only_allows_terminal_status(self) -> None:
+        now = datetime(2026, 5, 18, 20, 30, tzinfo=UTC)
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            record = build_record(
+                predicate={"type": "not_before", "due_at": "2026-05-18T21:15:00Z"},
+                prompt="continue",
+                cwd=Path(tmp),
+                target={"transport": "tmux", "tmux_socket": "/tmp/tmux/default", "pane": "%1"},
+                now=now,
+            )
+            record["id"] = "wake_archive"
+            active_path = write_record(root, record)
+            with self.assertRaises(ValueError):
+                archive_record(root, "wake_archive", now=now)
+            record["status"] = "cancelled"
+            terminal_path = write_record(root, record)
+            active_path.unlink(missing_ok=True)
+
+            archived = archive_record(root, "wake_archive", now=now)
+
+            self.assertFalse(terminal_path.exists())
+            data = json.loads(archived.read_text())
+            self.assertEqual(data["status"], "archived")
+            self.assertEqual(data["previous_status"], "cancelled")
+            self.assertEqual(data["events"][-1]["type"], "archived")
+
+    def test_archive_terminal_records_skips_active_records(self) -> None:
+        now = datetime(2026, 5, 18, 20, 30, tzinfo=UTC)
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            pending = build_record(
+                predicate={"type": "not_before", "due_at": "2026-05-18T21:15:00Z"},
+                prompt="pending",
+                cwd=Path(tmp),
+                target={"transport": "tmux", "tmux_socket": "/tmp/tmux/default", "pane": "%1"},
+                now=now,
+            )
+            pending["id"] = "wake_pending"
+            write_record(root, pending)
+            failed = dict(pending)
+            failed["id"] = "wake_failed"
+            failed["status"] = "failed"
+            write_record(root, failed)
+
+            paths = archive_terminal_records(root, now=now)
+
+            self.assertEqual([path.name for path in paths], ["wake_failed.json"])
+            self.assertTrue((root / "pending" / "wake_pending.json").exists())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- adds the Codex Wake Python package with `codex-wake` and `codex-waked` console scripts
- implements wake record creation, predicate polling, tmux canonical-prompt injection, Codex hook ack/context loading, runtime archival, and stdio app-server dispatch
- documents runtime state, app-server mode, hook configuration, roadmap lanes, and installed runtime verification

## Validation

- `PYTHONPATH=src python -m unittest discover -s tests -p 'test_*.py'`
- `python /home/ecochran76/workspace.local/agent-policies/repo-policy-selector/scripts/audit_planning_contract.py --repo-root /home/ecochran76/workspace.local/codex-wake --json`
- installed virtualenv smoke for `codex-wake`, `codex-waked`, CLI lifecycle, daemon predicate movement, hook ack, and app-server-targeted wake creation

## Notes

- live tmux dispatch was not attempted without a disposable Codex TUI pane target; injector behavior is covered with a fake tmux runner
- live app-server dispatch was not attempted without a real target thread id; stdio payload behavior is covered with a fake app-server client
- WebSocket app-server dispatch is intentionally deferred because current Codex docs mark it experimental/unsupported and require auth/TLS for non-loopback use

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CochranResearchGroup/codesmith/codex-wake/pr/1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->